### PR TITLE
Don't send a Diag event about a bad plan when a subtest dies

### DIFF
--- a/lib/Test2/AsyncSubtest.pm
+++ b/lib/Test2/AsyncSubtest.pm
@@ -9,7 +9,7 @@ use Test2::Hub::AsyncSubtest();
 use Test2::Util::Trace();
 use Test2::Event::Exception();
 
-use Test2::Util::HashBase qw/name hub events _finished/;
+use Test2::Util::HashBase qw/name hub errored events _finished/;
 
 our @CARP_NOT = qw/Test2::Tools::AsyncSubtest/;
 
@@ -80,6 +80,7 @@ sub run {
             ),
         );
         $hub->send($e);
+        $self->{+ERRORED} = 1;
     }
 
     return $hub->is_passing;
@@ -122,6 +123,9 @@ sub event_data {
 
 sub diagnostics {
     my $self = shift;
+    # If the subtest died then we've already sent an appropriate event. No
+    # need to send another telling the user that the plan was wrong.
+    return if $self->{+ERRORED};
     my $hub = $self->{+HUB};
     return if $hub->check_plan;
     return "Bad subtest plan, expected " . $hub->plan . " but ran " . $hub->count;


### PR DESCRIPTION
… when a subtest dies

When the subtest dies we already send an Exception event. Sending an Diag
event about a bad plan is not helpful.