### PR TITLE
add set_column_alias()

### DIFF
--- a/lib/Test2/Compare/Delta.pm
+++ b/lib/Test2/Compare/Delta.pm
@@ -74,6 +74,17 @@ sub add_column {
     $COLUMNS{$name} = \%params;
 }
 
+sub set_column_alias {
+    my ($class, $name, $alias) = @_;
+
+    croak "Tried to alias a non-existent column"
+        unless exists $COLUMNS{$name};
+
+    croak "Missing alias" unless defined $alias;
+
+    $COLUMNS{$name}->{alias} = $alias;
+}
+
 sub init {
     my $self = shift;
 
@@ -356,6 +367,11 @@ This will remove the specified column. This will return true if the column
 existed and was removed. This will return false if the column did not exist. No
 exceptions are thrown, if a missing column is a problem then you need to check
 the return yourself.
+
+=item $class->set_column_alias($NAME, $ALIAS)
+
+This can be used to change the table header, overriding the default column
+names with new ones.
 
 =back
 

--- a/t/modules/Compare/Delta.t
+++ b/t/modules/Compare/Delta.t
@@ -502,6 +502,42 @@ subtest custom_columns => sub {
     is($CLASS->remove_column('FOO'), 1, "Removed the column");
 };
 
+subtest set_column_alias => sub {
+    $CLASS->set_column_alias(PATH => ' ');
+    is(
+        $CLASS->table_header,
+        [' ', qw/LNs GOT OP CHECK LNs/],
+        "hide column name"
+    );
+
+    $CLASS->set_column_alias(GLNs => 'Now This');
+    is(
+        $CLASS->table_header,
+        [' ', 'Now This', qw/GOT OP CHECK LNs/],
+        "column name with spaces"
+    );
+
+    $CLASS->add_column('NEW' => sub { '' });
+    $CLASS->set_column_alias(NEW => 'OLD');
+    is(
+        $CLASS->table_header,
+        [' ', 'Now This', qw/GOT OP CHECK LNs OLD/],
+        "change added column name"
+    );
+
+    like(
+        dies { $CLASS->set_column_alias('OP') },
+        qr/Missing alias/,
+        'Missing alias'
+    );
+
+    like(
+        dies { $CLASS->set_column_alias(DNE => 'NOPE') },
+        qr/Tried to alias a non-existent column/,
+        'Needs existing column name'
+    );
+};
+
 subtest overload => sub {
     no warnings 'once';
     {


### PR DESCRIPTION
Gives consumers an easy way to change their column names. eg

    Test2::Compare::Delta->set_column_alias(GOT   => 'CONTROL');
    Test2::Compare::Delta->set_column_alias(CHECK => 'CANDIDATE');
