### PR TITLE
perlcritic tweaks: commas and semicolons

### DIFF
--- a/lib/Test2/Compare.pm
+++ b/lib/Test2/Compare.pm
@@ -59,7 +59,7 @@ sub build {
     die $err unless $ok;
 
     return $build;
-};
+}
 
 sub strict_convert  { convert($_[0], 1) }
 sub relaxed_convert { convert($_[0], 0) }
@@ -102,7 +102,7 @@ sub convert {
 
     if ($type eq 'SCALAR') {
         my $nested = convert($$thing, $strict);
-        return Test2::Compare::Scalar->new(item => $nested)
+        return Test2::Compare::Scalar->new(item => $nested);
     }
 
     return Test2::Compare::Ref->new(input => $thing)

--- a/lib/Test2/Compare/Custom.pm
+++ b/lib/Test2/Compare/Custom.pm
@@ -33,7 +33,7 @@ sub verify {
         got      => $got,
         exists   => $exists,
         operator => $self->{+OPERATOR},
-        name     => $self->{+NAME}
+        name     => $self->{+NAME},
     );
 
     return $ok;

--- a/lib/Test2/Compare/Delta.pm
+++ b/lib/Test2/Compare/Delta.pm
@@ -210,7 +210,7 @@ sub filter_visible {
     return \@deltas;
 }
 
-sub table_header { [map {$COLUMNS{$_}->{alias} || $_} @COLUMN_ORDER] };
+sub table_header { [map {$COLUMNS{$_}->{alias} || $_} @COLUMN_ORDER] }
 
 sub table_op {
     my $self = shift;

--- a/lib/Test2/Compare/Event.pm
+++ b/lib/Test2/Compare/Event.pm
@@ -15,7 +15,7 @@ use Test2::Util::HashBase qw/etype/;
 sub name {
     my $self = shift;
     my $etype = $self->etype;
-    return "<EVENT: $etype>"
+    return "<EVENT: $etype>";
 }
 
 sub meta_class  { 'Test2::Compare::EventMeta' }

--- a/lib/Test2/Compare/Ref.pm
+++ b/lib/Test2/Compare/Ref.pm
@@ -26,7 +26,7 @@ sub init {
 
 sub operator { '==' }
 
-sub name { render_ref($_[0]->{+INPUT}) };
+sub name { render_ref($_[0]->{+INPUT}) }
 
 sub verify {
     my $self = shift;

--- a/lib/Test2/Compare/Regex.pm
+++ b/lib/Test2/Compare/Regex.pm
@@ -27,7 +27,7 @@ sub stringify_got { 1 }
 
 sub operator { 'eq' }
 
-sub name { "" . $_[0]->{+INPUT} };
+sub name { "" . $_[0]->{+INPUT} }
 
 sub verify {
     my $self = shift;

--- a/lib/Test2/Plugin/ExitSummary.pm
+++ b/lib/Test2/Plugin/ExitSummary.pm
@@ -9,7 +9,7 @@ use Test2::API qw/test2_add_callback_exit/;
 my $ADDED_HOOK = 0;
 sub import { test2_add_callback_exit(\&summary) unless $ADDED_HOOK++ }
 
-sub active { $ADDED_HOOK };
+sub active { $ADDED_HOOK }
 
 sub summary {
     my ($ctx, $real, $new) = @_;

--- a/lib/Test2/Plugin/SRand.pm
+++ b/lib/Test2/Plugin/SRand.pm
@@ -28,11 +28,11 @@ sub import {
 
     if (@_) {
         ($SEED) = @_;
-        $FROM = 'import arg'
+        $FROM = 'import arg';
     }
     elsif(exists $ENV{T2_RAND_SEED}) {
         $SEED = $ENV{T2_RAND_SEED};
-        $FROM = 'environment variable'
+        $FROM = 'environment variable';
     }
     else {
         my @ltime = localtime;
@@ -76,6 +76,8 @@ sub import {
 }
 
 1;
+
+__END__
 
 =pod
 

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -408,11 +408,11 @@ sub event($;$) {
         );
     }
     elsif (!ref $spec) {
-        croak "'$spec' is not a valid event specification"
+        croak "'$spec' is not a valid event specification";
     }
     elsif (reftype($spec) eq 'CODE') {
         $event = build('Test2::Compare::Event', $spec);
-        $event->set_etype($intype),
+        $event->set_etype($intype);
         $event->set_builder($spec);
     }
     else {

--- a/lib/Test2/Tools/Exception.pm
+++ b/lib/Test2/Tools/Exception.pm
@@ -39,7 +39,7 @@ sub lives(&) {
     # If the eval failed we want to set $@ to the error.
     $@ = $err;
     return 0;
-};
+}
 
 1;
 

--- a/lib/Test2/Util/Table.pm
+++ b/lib/Test2/Util/Table.pm
@@ -16,7 +16,7 @@ BEGIN {
     my ($ok, $err) = try { require Term::ReadKey };
     $ok &&= Term::ReadKey->can('GetTerminalSize');
     *USE_TERM_READKEY = $ok ? sub() { 1 } : sub() { 0 };
-};
+}
 
 sub term_size {
     return $ENV{T2_TERM_SIZE} if $ENV{T2_TERM_SIZE};


### PR DESCRIPTION
The only significant change is in lib/Test2/Tools/Compare.pm.