### PR TITLE
Fix missing POD tag in Bundle/More.pm

### DIFF
--- a/lib/Test2/Bundle/More.pm
+++ b/lib/Test2/Bundle/More.pm
@@ -155,7 +155,7 @@ Instead you must plan in a seperate statement:
 
 =item You have 3 subs imported for use in planning
 
-Use C<plan($count)>, <skip_all($reason)>, or C<done_testing()> for your
+Use C<plan($count)>, C<skip_all($reason)>, or C<done_testing()> for your
 planning.
 
 =item isa_ok accepts different arguments


### PR DESCRIPTION
Found a missing POD tag browsing the module docs on MetaCPAN.