### PR TITLE
added DF() shortcut meaning "defined but false"

### DIFF
--- a/lib/Test2/Bundle/Extended.pm
+++ b/lib/Test2/Bundle/Extended.pm
@@ -32,7 +32,7 @@ use Test2::Tools::Compare qw{
     in_set not_in_set check_set
     item field call call_list call_hash prop check all_items all_keys all_vals all_values
     end filter_items
-    T F D E DNE FDNE
+    T F D DF E DNE FDNE
     event fail_events
     exact_ref
 };
@@ -84,7 +84,7 @@ our @EXPORT = qw{
     in_set not_in_set check_set
     item field call call_list call_hash prop check all_items all_keys all_vals all_values
     end filter_items
-    T F D E DNE FDNE
+    T F D DF E DNE FDNE
     event fail_events
     exact_ref
 };
@@ -359,6 +359,8 @@ See L<Test2::Tools::Compare>.
 =item $check = F()
 
 =item $check = D()
+
+=item $check = DF()
 
 =item $check = DNE()
 

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -64,7 +64,7 @@ our @EXPORT_OK = qw{
     in_set not_in_set check_set
     item field call call_list call_hash prop check all_items all_keys all_vals all_values
     end filter_items
-    T F D DNE FDNE E
+    T F D DF DNE FDNE E
     event fail_events
     exact_ref
 };
@@ -149,6 +149,15 @@ sub D() {
     my @caller = caller;
     Test2::Compare::Custom->new(
         code => sub { defined $_ ? 1 : 0 }, name => 'DEFINED', operator => 'DEFINED()',
+        file => $caller[1],
+        lines => [$caller[2]],
+    );
+}
+
+sub DF() {
+    my @caller = caller;
+    Test2::Compare::Custom->new(
+        code => sub { defined $_ && ! $_ ? 1 : 0 }, name => 'DEFINED BUT FALSE', operator => 'DEFINED() && FALSE()',
         file => $caller[1],
         lines => [$caller[2]],
     );
@@ -786,6 +795,20 @@ This will pass:
 This will fail:
 
     is(undef, D(), 'foo is defined');
+
+=item $check = DF()
+
+This is to verify that the value in the C<$got> structure is defined but false.
+Any false value other than C<undef> will pass.
+
+This will pass:
+
+    is(0, DF(), 'foo is defined but false');
+
+These will fail:
+
+    is(undef, DF(), 'foo is defined but false');
+    is(1, DF(), 'foo is defined but false');
 
 =item $check = DNE()
 

--- a/t/modules/Bundle/Extended.t
+++ b/t/modules/Bundle/Extended.t
@@ -26,7 +26,7 @@ imported_ok qw{
     in_set not_in_set check_set
     item field call call_list call_hash prop check all_items all_keys all_vals all_values
     end filter_items
-    T F D E DNE FDNE
+    T F D DF E DNE FDNE
     event fail_events
     exact_ref
 };

--- a/t/modules/Tools/Compare.t
+++ b/t/modules/Tools/Compare.t
@@ -19,7 +19,7 @@ subtest simple => sub {
         in_set not_in_set check_set
         item field call call_list call_hash prop check all_items all_keys all_vals all_values
         end filter_items
-        T F D E DNE FDNE
+        T F D DF E DNE FDNE
         event
         exact_ref
     };
@@ -260,6 +260,26 @@ subtest shortcuts => sub {
         intercept { is(undef, D(), "not defined") },
         array { event Ok => { pass => 0 } },
         "undef is not defined"
+    );
+
+    is(0,            DF(), "defined but false");
+    is('',           DF(), "defined but false");
+
+    like(
+        intercept {
+          is(undef,        DF());
+          is(1,            DF());
+          is(' ',          DF());
+          is('0 but true', DF());
+        },
+        array {
+          filter_items { grep { !$_->isa('Test2::Event::Diag') } @_ };
+          event Ok => { pass => 0 };
+          event Ok => { pass => 0 };
+          event Ok => { pass => 0 };
+          event Ok => { pass => 0 };
+        },
+        "got fail for DF"
     );
 
     is([undef], [E()],   "does exist");


### PR DESCRIPTION
As discussed on IRC this PR implements a DF() shortcut meaning "defined but false". I hope I have added appropriate documentation in the right places. I haven't changed any version numbers or Changes etc.