### PR TITLE
Address Extended + Moose conflict

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -21,6 +21,7 @@ repository.type = git
 [Prereqs]
 perl          = 5.008001
 Test2         = 1.302032
+Importer      = 0.010
 B             = 0
 Carp          = 0
 List::Util    = 0

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -61,7 +61,7 @@ our @EXPORT = qw/is like/;
 our @EXPORT_OK = qw{
     is like isnt unlike
     match mismatch validator
-    hash array bag object meta number string subset
+    hash array bag object meta meta_check number string subset
     in_set not_in_set check_set
     item field call call_list call_hash prop check all_items all_keys all_vals all_values
     end filter_items
@@ -139,12 +139,13 @@ sub unlike($$;$@) {
     return $delta ? 1 : 0;
 }
 
-sub meta(&)   { build('Test2::Compare::Meta',          @_) }
-sub hash(&)   { build('Test2::Compare::Hash',          @_) }
-sub array(&)  { build('Test2::Compare::Array',         @_) }
-sub bag(&)    { build('Test2::Compare::Bag',           @_) }
-sub object(&) { build('Test2::Compare::Object',        @_) }
-sub subset(&) { build('Test2::Compare::OrderedSubset', @_) }
+sub meta(&)       { build('Test2::Compare::Meta',          @_) }
+sub meta_check(&) { build('Test2::Compare::Meta',          @_) }
+sub hash(&)       { build('Test2::Compare::Hash',          @_) }
+sub array(&)      { build('Test2::Compare::Array',         @_) }
+sub bag(&)        { build('Test2::Compare::Bag',           @_) }
+sub object(&)     { build('Test2::Compare::Object',        @_) }
+sub subset(&)     { build('Test2::Compare::OrderedSubset', @_) }
 
 sub U() {
     my @caller = caller;
@@ -1191,7 +1192,11 @@ B<Note: None of these are exported by default. You need to request them.>
 
 =item meta { ... }
 
-Build a meta check
+=item meta_check { ... }
+
+Build a meta check. If you are using L<Moose> then the C<meta()> function would
+conflict with the one exported by L<Moose>, in such cases C<meta_check()> is
+available. Neither is exported by default.
 
 =item prop $NAME => $VAL
 

--- a/t/modules/Bundle/Extended.t
+++ b/t/modules/Bundle/Extended.t
@@ -79,6 +79,20 @@ subtest utf8 => sub {
     }
 };
 
+subtest "rename imports" => sub {
+    package A::Consumer;
+    use Test2::Bundle::Extended ':v1', '!subtest', subtest => {-as => 'a_subtest'};
+    imported_ok('a_subtest');
+    not_imported_ok('subtest');
+};
+
+subtest "no meta" => sub {
+    package B::Consumer;
+    use Test2::Bundle::Extended '!meta';
+    imported_ok('meta_check');
+    not_imported_ok('meta');
+};
+
 done_testing;
 
 1;


### PR DESCRIPTION
 * Document Moose/Extended conflict.
 * Add meta_check alternative to Compare tools.
 * Use Importer to make it possible to rename exports.
 * Use Importer to import subtets while we are at it.
 * Add default exports as the 'v1' tag to Extended bundle.
 * Add 'meta_check' tag to extended to simplify using meta_check.
 * Document the use of 'v2' tag in the future.

I do not think a v2 tag is necessary yet. I do not think the meta()
conflict is compeling enough for a new 'recommended' tag. I do however
think having the 'meta_check' tag to make it simple to resolve the
conflict is important.

Fixes #38