### PR TITLE
Fix bad use of \d

### DIFF
--- a/lib/Test2/Plugin/ExitSummary.pm
+++ b/lib/Test2/Plugin/ExitSummary.pm
@@ -27,7 +27,7 @@ sub summary {
         if $real;
 
     $ctx->diag("Did not follow plan: expected $plan, ran $count.")
-        if $plan && $plan =~ m/^\d+$/ && defined $count && $count != $plan;
+        if $plan && $plan =~ m/^[0-9]+$/ && defined $count && $count != $plan;
 }
 
 1;

--- a/lib/Test2/Tools/Basic.pm
+++ b/lib/Test2/Tools/Basic.pm
@@ -78,7 +78,7 @@ sub plan {
     my $plan = shift;
     my $ctx = context();
 
-    if ($plan && $plan =~ m/\D/) {
+    if ($plan && $plan =~ m/[^0-9]/) {
         if ($plan eq 'tests') {
             $plan = shift;
         }

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -1036,7 +1036,7 @@ B<Note: None of these are exported by default. You need to request them.>
         item 'f';
 
         # Remove any REMAINING items that contain 0-9.
-        filter_items { grep {m/\D/} @_ };
+        filter_items { grep {!m/[0-9]/} @_ };
 
         # Set checks that apply to all items. Can be done multiple times, and
         # each call can define multiple checks, all will be run.

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -583,7 +583,7 @@ your data. There are both 'strict' and 'relaxed' versions of the tools.
     # regex to approximate a field.
     like(
         $some_hash,
-        {a => 1, b => qr/\d+/},
+        {a => 1, b => qr/[0-9]+/},
         "'a' is 1, 'b' is an integer, we don't care about 'c'."
     );
 
@@ -656,7 +656,7 @@ provided and converted to a specification for you.
         $some_hash,
         hash {    # Note: the hash function is not exported by default
             field a => 1;
-            field b => match(qr/\d+/);    # Note: The match function is not exported by default
+            field b => match(qr/[0-9]+/);    # Note: The match function is not exported by default
             # Don't care about other fields.
         },
         "The hash comparison is not strict"
@@ -708,7 +708,7 @@ In this tool regexes will stringify the thing they are checking.
 
     like(
         $some_hash,
-        {a => 1, b => qr/\d+/},
+        {a => 1, b => qr/[0-9]+/},
         "'a' is 1, 'b' is an integer, we don't care about other fields"
     );
 


### PR DESCRIPTION
`\d` matches any unicode digit which is not what we want.

Since we don't want to use `//a` (since that only works on more recent perls) this code changes `\d` to `[0-9]`.

Also, one of the examples in the `filter_remaining` seems to be wrong.  I tried to fix it.