### PR TITLE
move import of Test2::Compare:: types into Test2::Compare

### DIFF
--- a/lib/Test2/Compare.pm
+++ b/lib/Test2/Compare.pm
@@ -17,6 +17,25 @@ our @EXPORT_OK = qw{
 };
 use base 'Exporter';
 
+require Test2::Compare::Array;
+require Test2::Compare::Bag;
+require Test2::Compare::Custom;
+require Test2::Compare::Event;
+require Test2::Compare::Hash;
+require Test2::Compare::Meta;
+require Test2::Compare::Number;
+require Test2::Compare::Object;
+require Test2::Compare::OrderedSubset;
+require Test2::Compare::Pattern;
+require Test2::Compare::Ref;
+require Test2::Compare::DeepRef;
+require Test2::Compare::Regex;
+require Test2::Compare::Scalar;
+require Test2::Compare::Set;
+require Test2::Compare::String;
+require Test2::Compare::Undef;
+require Test2::Compare::Wildcard;
+
 sub compare {
     my ($got, $check, $convert) = @_;
 

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -16,25 +16,6 @@ use Test2::Compare qw{
     strict_convert relaxed_convert
 };
 
-use Test2::Compare::Array();
-use Test2::Compare::Bag();
-use Test2::Compare::Custom();
-use Test2::Compare::Event();
-use Test2::Compare::Hash();
-use Test2::Compare::Meta();
-use Test2::Compare::Number();
-use Test2::Compare::Object();
-use Test2::Compare::OrderedSubset();
-use Test2::Compare::Pattern();
-use Test2::Compare::Ref();
-use Test2::Compare::DeepRef();
-use Test2::Compare::Regex();
-use Test2::Compare::Scalar();
-use Test2::Compare::Set();
-use Test2::Compare::String();
-use Test2::Compare::Undef();
-use Test2::Compare::Wildcard();
-
 %Carp::Internal = (
     %Carp::Internal,
     'Test2::Tools::Compare'         => 1,


### PR DESCRIPTION
This prevents the case where Test2::Compare is used in a standalone
manner and the comparison subtypes aren't loaded. In that case the user
had to load them manually (and know what all were needed) in order to
avoid exceptions.