### PR TITLE
Use +0 to display scalars as numbers.

### DIFF
--- a/lib/Test2/Tools/ClassicCompare.pm
+++ b/lib/Test2/Tools/ClassicCompare.pm
@@ -229,8 +229,8 @@ sub cmp_ok($$$;$@) {
         $display_exp = defined($exp) ? "$exp" : undef;
     }
     elsif($type eq 'num') {
-        $display_got = defined($got) ? sprintf("%D", $got) : undef;
-        $display_exp = defined($exp) ? sprintf("%D", $exp) : undef;
+        $display_got = defined($got) ? $got + 0 : undef;
+        $display_exp = defined($exp) ? $exp + 0 : undef;
     }
     else { # Well, we did what we could.
         $display_got = $got;

--- a/t/modules/Tools/ClassicCompare.t
+++ b/t/modules/Tools/ClassicCompare.t
@@ -282,4 +282,60 @@ like(
     "Got exception in test"
 );
 
+
+note "cmp_ok() displaying good numbers"; {
+    my $have = 1.23456;
+    my $want = 4.5678;
+    like(
+        intercept {
+            cmp_ok($have, '>', $want);
+        },
+        array {
+            fail_events Ok => sub {
+                call pass => 0;
+            };
+
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK/],
+                    rows   => [
+                      [$have, '>', $want],
+                    ],
+                );
+            };
+
+            end;
+        },
+    );
+}
+
+
+note "cmp_ok() displaying bad numbers"; {
+    my $have = "zero";
+    my $want = "3point5";
+    like(
+        intercept {
+            warnings { cmp_ok($have, '>', $want) };
+        },
+        array {
+            fail_events Ok => sub {
+                call pass => 0;
+            };
+
+            event Diag => sub {
+                call message => table(
+                    header => [qw/TYPE GOT OP CHECK/],
+                    rows   => [
+                      ['num',   0,      '>',    '3'],
+                      ['orig',  $have,  '',     $want],
+                    ],
+                );
+            };
+
+            end;
+        },
+    );
+}
+
+
 done_testing;


### PR DESCRIPTION
The intent is to show how Perl saw them.

sprintf "%D" meant they'd always be displayed as integers.

Fixes #53