### PR TITLE
Add try_ok to tools/exception and extended bundle

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+    - Add try_ok to Tools/Exception
+
 0.000058  2016-08-13 13:06:10-07:00 America/Los_Angeles
 
     - No changes from last trial

--- a/lib/Test2/Bundle/Extended.pm
+++ b/lib/Test2/Bundle/Extended.pm
@@ -52,7 +52,7 @@ use Test2::Tools::Encoding  qw/set_encoding/;
 use Test2::Tools::Exports   qw/imported_ok not_imported_ok/;
 use Test2::Tools::Ref       qw/ref_ok ref_is ref_is_not/;
 use Test2::Tools::Mock      qw/mock mocked/;
-use Test2::Tools::Exception qw/dies lives/;
+use Test2::Tools::Exception qw/try_ok dies lives/;
 
 our @EXPORT = qw{
     ok pass fail diag note todo skip
@@ -74,7 +74,7 @@ our @EXPORT = qw{
     imported_ok not_imported_ok
     ref_ok ref_is ref_is_not
     mock mocked
-    dies lives
+    dies lives try_ok
 
     is like isnt unlike
     match mismatch validator
@@ -532,6 +532,8 @@ See L<Test2::Tools::Exception>.
 =item $exception = dies { ... }
 
 =item $bool = lives { ... }
+
+=item $bool = try_ok { ... }
 
 =back
 

--- a/t/modules/Bundle/Extended.t
+++ b/t/modules/Bundle/Extended.t
@@ -20,6 +20,8 @@ imported_ok qw{
     ref_ok ref_is ref_is_not
     mock mocked
 
+    dies lives try_ok
+
     is like isnt unlike
     match mismatch validator
     hash array object meta number string

--- a/t/modules/Tools/Exception.t
+++ b/t/modules/Tools/Exception.t
@@ -2,9 +2,11 @@ use Test2::Bundle::Extended -target => 'Test2::Tools::Exception';
 
 {
     package Foo;
-    use Test2::Tools::Exception qw/dies lives/;
-    ::imported_ok(qw/dies lives/);
+    use Test2::Tools::Exception qw/dies lives try_ok/;
+    ::imported_ok(qw/dies lives try_ok/);
 }
+
+use Test2::API qw/intercept/;
 
 like(
     dies { die 'xyz' },
@@ -22,5 +24,22 @@ is(dies { 0 }, undef, "no exception");
 
 ok(!lives { die 'xxx' }, "it died");
 like($@, qr/xxx/, "Exception is available");
+
+try_ok { 0 } "No Exception from try_ok";
+
+my $err;
+is(
+    intercept { try_ok { die 'abc' } "foo"; $err = $@; },
+    array {
+        fail_events Ok => sub {
+            call name => "foo";
+            call pass => 0;
+        };
+        event Diag => sub { msg => match qr/abc/; };
+    },
+    "Got failure + diag from try_ok"
+);
+
+like($err, qr/abc/, '$@ has the exception');
 
 done_testing;


### PR DESCRIPTION
Fixes #49 
I used try_ok instead off lives_ok to avoid conflicts with anyone already bringing in a common library for this.