### PR TITLE
Compare: make convert() more flexible

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 {{$NEXT}}
 
+    - Export convert() in Test2::Compare
+    - Make convert more flexible
+    - Document how to write a compare tool with custom behavior
+
 0.000058  2016-08-13 13:06:10-07:00 America/Los_Angeles
 
     - No changes from last trial


### PR DESCRIPTION
This is necessary for the tools described in the #63 discussion.