### PR TITLE
Use Importer versions sets for is() back-compat change

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,12 +1,17 @@
 {{$NEXT}}
 
+    - Introduce v2 pin for Extended bundle
+        - Implicit end() for checks inside is()
+    - Introduce v2 pin for Compare tools
+        - Implicit end() for checks inside is()
     - Create Test2::Compare::Negatable
     - Add bool() for deep comparisons
-    - Implicit end() for checks inside is()
     - Add try_ok to Tools/Exception
     - Export convert() in Test2::Compare
     - Make convert more flexible
     - Document how to write a compare tool with custom behavior
+    - Make it possible to warn about deprecate versions
+    - Use Importer pin features (Needs Importer 0.021)
 
 0.000058  2016-08-13 13:06:10-07:00 America/Los_Angeles
 

--- a/README
+++ b/README
@@ -35,11 +35,36 @@ DESCRIPTION
     important as it helps avoid the problem where a package exports
     much-desired tools, but also produces undesirable side effects.
 
+NOTE ON EXPORT PINS
+
+    The current pin used by all of Test::Suite is v2.
+
+    Export pins are how Test2::Suite manages changes that could break
+    backwords compatability. If we need to break backwards compatability we
+    will do so by releasing a new pin. Old pins will continue to import the
+    old functionality while new pins will import the new functionality.
+
+    There are several ways to specify a pin:
+
+        # Import all the defaults provided by the 'v2' pin
+        use Package ':v2';
+    
+        # Import foo, bar, and baz deom the v2 pin.
+        use Package '+v2' => [qw/foo bar baz/];
+    
+        # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+        use Package qw/+v2 foo +v1 bar baz/;
+
+    If you do not specify a pin the default is to use the v1 pin (for
+    legacy reasons). When the $AUTHOR_TESTING environment variable is set,
+    importing without a pin will produce a warning. In the future this
+    warning may occur without the environment variable being set.
+
 INCLUDED BUNDLES
 
     Extended
 
-          use Test2::Bundle::Extended;
+          use Test2::Bundle::Extended ':v2';
           # strict and warnings are on for you now.
       
           ok(...);
@@ -60,7 +85,7 @@ INCLUDED BUNDLES
 
     More
 
-          use Test2::Bundle::More;
+          use Test2::Bundle::More ':v2';
           use strict;
           use warnings;
       
@@ -88,7 +113,7 @@ INCLUDED BUNDLES
 
     Simple
 
-          use Test2::Bundle::Simple;
+          use Test2::Bundle::Simple ':v2';
           use strict;
           use warnings;
       

--- a/README.md
+++ b/README.md
@@ -35,11 +35,36 @@ then a Bundle that loads them both. This is important as it helps avoid the
 problem where a package exports much-desired tools, but
 also produces undesirable side effects.
 
+# NOTE ON EXPORT PINS
+
+**The current pin used by all of Test::Suite is `v2`.**
+
+Export pins are how [Test2::Suite](https://metacpan.org/pod/Test2::Suite) manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the `v1` pin (for legacy
+reasons). When the `$AUTHOR_TESTING` environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
 # INCLUDED BUNDLES
 
 - Extended
 
-        use Test2::Bundle::Extended;
+        use Test2::Bundle::Extended ':v2';
         # strict and warnings are on for you now.
 
         ok(...);
@@ -60,7 +85,7 @@ also produces undesirable side effects.
 
 - More
 
-        use Test2::Bundle::More;
+        use Test2::Bundle::More ':v2';
         use strict;
         use warnings;
 
@@ -87,7 +112,7 @@ also produces undesirable side effects.
 
 - Simple
 
-        use Test2::Bundle::Simple;
+        use Test2::Bundle::Simple ':v2';
         use strict;
         use warnings;
 

--- a/dist.ini
+++ b/dist.ini
@@ -21,7 +21,7 @@ repository.type = git
 [Prereqs]
 perl          = 5.008001
 Test2         = 1.302032
-Importer      = 0.010
+Importer      = 0.022
 B             = 0
 Carp          = 0
 List::Util    = 0

--- a/lib/Test2/Bundle/Extended.pm
+++ b/lib/Test2/Bundle/Extended.pm
@@ -26,7 +26,8 @@ use Test2::Tools::Basic qw{
 };
 
 use Test2::Tools::Compare qw{
-    is like isnt unlike
+    +v2
+    is like isnt unlike is_v1 is_v2
     match mismatch validator
     hash array bag object meta meta_check number string subset bool
     in_set not_in_set check_set
@@ -87,9 +88,24 @@ our @EXPORT = qw{
     exact_ref
 };
 
-our %EXPORT_TAGS = (
-    'v1' => \@EXPORT,
-);
+sub IMPORTER_MENU {
+    return (
+        export_anon => { is => \&is_v1 },
+        export => \@EXPORT,
+
+        export_pins => {
+            root_name => 'no-pin',
+            'v1' => {
+                inherit => 'no-pin',
+                export_anon => { is => \&is_v1 },
+            },
+            'v2' => {
+                inherit => 'v1',
+                export_anon => { is => \&is_v2 },
+            },
+        },
+    );
+}
 
 my $SRAND;
 sub import {
@@ -151,7 +167,7 @@ extensively to test L<Test2::Suite> itself.
 
 =head1 SYNOPSIS
 
-    use Test2::Bundle::Extended ':v1';
+    use Test2::Bundle::Extended ':v2';
 
     ok(1, "pass");
 
@@ -184,7 +200,13 @@ The following are all identical:
 
     use Test2::Bundle::Extended ':DEFAULT';
 
-=item :v2 (FUTURE)
+=item :v2
+
+This version made a backwards incompatible change to C<is()> such that an
+implicit C<end()> is added to array and hash checks created via the compare
+DSL.
+
+=item :v3 (FUTURE)
 
 Does not exist yet. This will be populated if we find need to make incompatible
 changes to C<:v1>. This was we can move forward with a new tag without breaking

--- a/lib/Test2/Bundle/Extended.pm
+++ b/lib/Test2/Bundle/Extended.pm
@@ -16,11 +16,12 @@ use Test2::Plugin::ExitSummary;
 
 use Test2::API qw/intercept context/;
 
-use Test2::Tools::Event qw/gen_event/;
+use Test2::Tools::Event qw/+v2 gen_event/;
 
-use Test2::Tools::Defer qw/def do_def/;
+use Test2::Tools::Defer qw/+v2 def do_def/;
 
 use Test2::Tools::Basic qw{
+    +v2
     ok pass fail diag note todo skip
     plan skip_all done_testing bail_out
 };
@@ -39,21 +40,25 @@ use Test2::Tools::Compare qw{
 };
 
 use Test2::Tools::Warnings qw{
+    +v2
     warns warning warnings no_warnings
 };
 
-use Test2::Tools::ClassicCompare qw/cmp_ok/;
+use Test2::Tools::ClassicCompare qw/+v2 cmp_ok/;
 
 use Importer 'Test2::Tools::Subtest' => (
+    '+v2',
     subtest_buffered => { -as => 'subtest' },
 );
 
-use Test2::Tools::Class     qw/can_ok isa_ok DOES_ok/;
-use Test2::Tools::Encoding  qw/set_encoding/;
-use Test2::Tools::Exports   qw/imported_ok not_imported_ok/;
-use Test2::Tools::Ref       qw/ref_ok ref_is ref_is_not/;
-use Test2::Tools::Mock      qw/mock mocked/;
-use Test2::Tools::Exception qw/try_ok dies lives/;
+use Test2::Tools::Class     qw/+v2 can_ok isa_ok DOES_ok/;
+use Test2::Tools::Encoding  qw/+v2 set_encoding/;
+use Test2::Tools::Exports   qw/+v2 imported_ok not_imported_ok/;
+use Test2::Tools::Ref       qw/+v2 ref_ok ref_is ref_is_not/;
+use Test2::Tools::Mock      qw/+v2 mock mocked/;
+use Test2::Tools::Exception qw/+v2 try_ok dies lives/;
+
+use Test2::Util::Misc qw/deprecate_pins_before/;
 
 our @EXPORT = qw{
     ok pass fail diag note todo skip
@@ -92,6 +97,8 @@ sub IMPORTER_MENU {
     return (
         export_anon => { is => \&is_v1 },
         export => \@EXPORT,
+
+        export_on_use => deprecate_pins_before(2),
 
         export_pins => {
             root_name => 'no-pin',

--- a/lib/Test2/Bundle/Extended.pm
+++ b/lib/Test2/Bundle/Extended.pm
@@ -184,40 +184,48 @@ extensively to test L<Test2::Suite> itself.
 
 =head1 RESOLVING CONFLICTS WITH MOOSE
 
-    use Test2::Bundle::Extended '!meta';
+    use Test2::Bundle::Extended qw/:v1 !meta/;
 
 L<Moose> and L<Test2::Bundle::Extended> both export very different C<meta()>
 subs. Adding C<'!meta'> to the import args will prevent the sub from being
 imported. This bundle also exports the sub under the name C<meta_check()> so
 you can use that spelling as an alternative.
 
-=head2 TAGS
+=head1 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head2 DIFFERENCES BETWEEN PINS
 
 =over 4
 
-=item :v1
+=item From v1 to v2
 
-=item :DEFAULT
-
-The following are all identical:
-
-    use Test2::Bundle::Extended;
-
-    use Test2::Bundle::Extended ':v1';
-
-    use Test2::Bundle::Extended ':DEFAULT';
-
-=item :v2
-
-This version made a backwards incompatible change to C<is()> such that an
-implicit C<end()> is added to array and hash checks created via the compare
-DSL.
-
-=item :v3 (FUTURE)
-
-Does not exist yet. This will be populated if we find need to make incompatible
-changes to C<:v1>. This was we can move forward with a new tag without breaking
-backwards compatibility.
+When you use C<is()> and the DSL provided by L<Test2::Tools::Compare>, there is
+now an implicit C<end()> call inside array and hash checks. In v1 there was no
+implicit C<end()>. This change has a lot of potential to break existing tests,
+that is why a new pin was needed.
 
 =back
 

--- a/lib/Test2/Bundle/Extended.pm
+++ b/lib/Test2/Bundle/Extended.pm
@@ -118,7 +118,7 @@ my $SRAND;
 sub import {
     my $class = shift;
 
-    my $caller = caller;
+    my @caller = caller(0);
     my (@exports, %options);
     while (my $arg = shift @_) {
         push @exports => $arg and next unless substr($arg, 0, 1) eq '-';
@@ -146,12 +146,12 @@ sub import {
     Test2::Plugin::UTF8->import() unless $no_utf8;
 
     my $target = delete $options{'-target'};
-    Test2::Tools::Target->import_into($caller, $target)
+    Test2::Tools::Target->import_into($caller[0], $target)
         if $target;
 
     croak "Unknown option(s): " . join(', ', keys %options) if keys %options;
 
-    Importer->import_into($class, $caller, @exports);
+    Importer->import_into($class, \@caller, @exports);
 }
 
 1;

--- a/lib/Test2/Bundle/More.pm
+++ b/lib/Test2/Bundle/More.pm
@@ -7,21 +7,26 @@ our $VERSION = '0.000059';
 use Test2::Plugin::ExitSummary;
 
 use Test2::Tools::Basic qw{
+    +v2
     ok pass fail skip todo diag note
     plan skip_all done_testing bail_out
 };
 
 use Test2::Tools::ClassicCompare qw{
+    +v2
     is is_deeply isnt like unlike cmp_ok
 };
 
-use Test2::Tools::Class qw/can_ok isa_ok/;
-use Test2::Tools::Subtest qw/subtest_streamed/;
+use Test2::Tools::Class qw/+v2 can_ok isa_ok/;
+use Test2::Tools::Subtest qw/+v2 subtest_streamed/;
 
 BEGIN {
     *BAIL_OUT = \&bail_out;
     *subtest  = \&subtest_streamed;
 }
+
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
 
 our @EXPORT = qw{
     ok pass fail skip todo diag note
@@ -33,7 +38,17 @@ our @EXPORT = qw{
 
     subtest
 };
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 1;
 

--- a/lib/Test2/Bundle/More.pm
+++ b/lib/Test2/Bundle/More.pm
@@ -69,13 +69,50 @@ L<Test::More>. See L<"KEY DIFFERENCES FROM Test::Simple"> for details.
 
 =head1 SYNOPSIS
 
-    use Test2::Bundle::More;
+    use Test2::Bundle::More ':v2';
 
     ok(1, "pass");
 
     ...
 
     done_testing;
+
+=head1 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head2 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
 
 =head1 PLUGINS
 

--- a/lib/Test2/Bundle/Simple.pm
+++ b/lib/Test2/Bundle/Simple.pm
@@ -43,11 +43,48 @@ L<Test::Simple>. See L<"KEY DIFFERENCES FROM Test::Simple"> for details.
 
 =head1 SYNOPSIS
 
-    use Test2::Bundle::Simple;
+    use Test2::Bundle::Simple ':v2';
 
     ok(1, "pass");
 
     done_testing;
+
+=head1 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head2 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
 
 =head1 PLUGINS
 

--- a/lib/Test2/Bundle/Simple.pm
+++ b/lib/Test2/Bundle/Simple.pm
@@ -8,8 +8,21 @@ use Test2::Plugin::ExitSummary;
 
 use Test2::Tools::Basic qw/ok plan done_testing skip_all/;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/ok plan done_testing skip_all/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 1;
 

--- a/lib/Test2/Bundle/Simple.pm
+++ b/lib/Test2/Bundle/Simple.pm
@@ -6,7 +6,7 @@ our $VERSION = '0.000059';
 
 use Test2::Plugin::ExitSummary;
 
-use Test2::Tools::Basic qw/ok plan done_testing skip_all/;
+use Test2::Tools::Basic qw/+v2 ok plan done_testing skip_all/;
 
 use Test2::Util::Misc qw/deprecate_pins_before/;
 use Importer Importer => qw/import/;

--- a/lib/Test2/Compare.pm
+++ b/lib/Test2/Compare.pm
@@ -203,7 +203,7 @@ C<Test2::Tools::ClassicCompare::is_deeply()>.
     package Test2::Tools::MyCheck;
 
     use Test2::Compare::MyCheck;
-    use Test2::Compare qw/compare/;
+    use Test2::Compare '+v2' => [qw/compare/];
 
     sub MyCheck {
         my ($got, $exp, $name, @diag) = @_;
@@ -232,6 +232,45 @@ C<Test2::Tools::ClassicCompare::is_deeply()>.
 See L<Test2::Compare::Base> for details about writing a custom check.
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
 
 =over 4
 

--- a/lib/Test2/Compare.pm
+++ b/lib/Test2/Compare.pm
@@ -10,12 +10,25 @@ use Test2::Util::Ref qw/rtype/;
 
 use Carp qw/croak/;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT_OK = qw{
     compare
     get_build push_build pop_build build
     strict_convert relaxed_convert convert
 };
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export_ok     => \@EXPORT_OK,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 sub compare {
     my ($got, $check, $convert) = @_;

--- a/lib/Test2/Suite.pm
+++ b/lib/Test2/Suite.pm
@@ -53,13 +53,38 @@ then a Bundle that loads them both. This is important as it helps avoid the
 problem where a package exports much-desired tools, but
 also produces undesirable side effects.
 
+=head1 NOTE ON EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
 =head1 INCLUDED BUNDLES
 
 =over 4
 
 =item Extended
 
-    use Test2::Bundle::Extended;
+    use Test2::Bundle::Extended ':v2';
     # strict and warnings are on for you now.
 
     ok(...);
@@ -80,7 +105,7 @@ See L<Test2::Bundle::Extended> for complete documentation.
 
 =item More
 
-    use Test2::Bundle::More;
+    use Test2::Bundle::More ':v2';
     use strict;
     use warnings;
 
@@ -107,7 +132,7 @@ See L<Test2::Bundle::More> for complete documentation.
 
 =item Simple
 
-    use Test2::Bundle::Simple;
+    use Test2::Bundle::Simple ':v2';
     use strict;
     use warnings;
 

--- a/lib/Test2/Tools/Basic.pm
+++ b/lib/Test2/Tools/Basic.pm
@@ -7,11 +7,24 @@ our $VERSION = '0.000059';
 use Carp qw/croak/;
 use Test2::API qw/context/;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw{
     ok pass fail diag note todo skip
     plan skip_all done_testing bail_out
 };
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 sub ok($;$@) {
     my ($bool, $name, @diag) = @_;

--- a/lib/Test2/Tools/Basic.pm
+++ b/lib/Test2/Tools/Basic.pm
@@ -147,7 +147,7 @@ diagnostics capabilities.
 
 =head1 SYNOPSIS
 
-    use Test2::Tools::Basic;
+    use Test2::Tools::Basic ':v2';
 
     ok($x, "simple test");
 
@@ -184,6 +184,46 @@ diagnostics capabilities.
     done_testing;
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 All subs are exported by default.
 

--- a/lib/Test2/Tools/Class.pm
+++ b/lib/Test2/Tools/Class.pm
@@ -118,7 +118,7 @@ some tools from L<Test::More>, but they have a more consistent interface.
 
 =head1 SYNOPSIS
 
-    use Test2::Tools::Class;
+    use Test2::Tools::Class ':v2';
 
     isa_ok($CLASS_OR_INSTANCE, $PARENT_CLASS1, $PARENT_CLASS2, ...);
     isa_ok($CLASS_OR_INSTANCE, [$PARENT_CLASS1, $PARENT_CLASS2, ...], "Test Name");
@@ -130,6 +130,46 @@ some tools from L<Test::More>, but they have a more consistent interface.
     DOES_ok($CLASS_OR_INSTANCE, [$ROLE1, $ROLE2, ...], "Test Name");
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 All subs are exported by default.
 

--- a/lib/Test2/Tools/Class.pm
+++ b/lib/Test2/Tools/Class.pm
@@ -9,8 +9,21 @@ use Test2::Util::Ref qw/render_ref/;
 
 use Scalar::Util qw/blessed/;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/can_ok isa_ok DOES_ok/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 # For easier grepping
 # sub isa_ok  is defined here

--- a/lib/Test2/Tools/ClassicCompare.pm
+++ b/lib/Test2/Tools/ClassicCompare.pm
@@ -4,8 +4,21 @@ use warnings;
 
 our $VERSION = '0.000059';
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/is is_deeply isnt like unlike cmp_ok/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 use Carp qw/carp/;
 use Scalar::Util qw/reftype/;

--- a/lib/Test2/Tools/ClassicCompare.pm
+++ b/lib/Test2/Tools/ClassicCompare.pm
@@ -330,7 +330,7 @@ unlike the L<Test2::Tools::Compare> plugin which has modified them.
 
 =head1 SYNOPSIS
 
-    use Test2::Tools::ClassicCompare qw/is is_deeply isnt like unlike cmp_ok/;
+    use Test2::Tools::ClassicCompare '+v2' => [qw/is is_deeply isnt like unlike cmp_ok/];
 
     is($got, $expect, "These are the same when stringified");
     isnt($got, $unexpect, "These are not the same when stringified");
@@ -343,6 +343,46 @@ unlike the L<Test2::Tools::Compare> plugin which has modified them.
     cmp_ok($GOT, $OP, $WANT, 'Compare these items using the specified operatr');
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 =over 4
 

--- a/lib/Test2/Tools/ClassicCompare.pm
+++ b/lib/Test2/Tools/ClassicCompare.pm
@@ -24,7 +24,7 @@ use Carp qw/carp/;
 use Scalar::Util qw/reftype/;
 
 use Test2::API qw/context/;
-use Test2::Compare qw/compare strict_convert/;
+use Test2::Compare qw/+v2 compare strict_convert/;
 use Test2::Util::Ref qw/rtype render_ref/;
 use Test2::Util::Table qw/table/;
 

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -16,6 +16,7 @@ use Test2::Compare qw{
     strict_convert relaxed_convert convert
 };
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
 use Importer Importer => qw/import/;
 
 use Test2::Compare::Array();
@@ -65,6 +66,9 @@ sub IMPORTER_MENU {
     return (
         export      => [qw/like/],
         export_anon => {is => \&is_v1},
+
+        export_on_use => deprecate_pins_before(2),
+
         export_ok   => [
             qw{
                 is like isnt unlike is_v1 is_v2

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -690,6 +690,44 @@ your data. There are both 'strict' and 'relaxed' versions of the tools.
         "'a' is 1, 'b' is an integer, we don't care about 'c'."
     );
 
+=head1 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head2 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+When you use C<is()> and the DSL provided by L<Test2::Tools::Compare>, there is
+now an implicit C<end()> call inside array and hash checks. In v1 there was no
+implicit C<end()>. This change has a lot of potential to break existing tests,
+that is why a new pin was needed.
+
+=back
+
 =head2 ADVANCED
 
 Declarative hash, array, and objects builders are available that allow you to

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -11,6 +11,7 @@ use Test2::API qw/context/;
 use Test2::Util::Ref qw/rtype/;
 
 use Test2::Compare qw{
+    +v2
     compare
     get_build push_build pop_build build
     strict_convert relaxed_convert convert

--- a/lib/Test2/Tools/Defer.pm
+++ b/lib/Test2/Tools/Defer.pm
@@ -117,7 +117,7 @@ are defined.
     use strict;
     use warnings;
 
-    use Test2::Tools::Defer;
+    use Test2::Tools::Defer ':v2';
 
     BEGIN {
         def ok => (1, 'pass');
@@ -138,6 +138,46 @@ are defined.
     done_testing;
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 =over 4
 

--- a/lib/Test2/Tools/Defer.pm
+++ b/lib/Test2/Tools/Defer.pm
@@ -12,8 +12,21 @@ use Test2::API qw{
     test2_pid test2_tid
 };
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/def do_def/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 my %TODO;
 

--- a/lib/Test2/Tools/Encoding.pm
+++ b/lib/Test2/Tools/Encoding.pm
@@ -6,11 +6,23 @@ use Carp qw/croak/;
 
 use Test2::API qw/test2_stack/;
 
-use base 'Exporter';
-
 our $VERSION = '0.000059';
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/set_encoding/;
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 sub set_encoding {
     my $enc = shift;

--- a/lib/Test2/Tools/Encoding.pm
+++ b/lib/Test2/Tools/Encoding.pm
@@ -56,11 +56,51 @@ encoding at will.
 
 =head1 SYNOPSIS
 
-    use Test2::Tools::Encoding;
+    use Test2::Tools::Encoding ':v2';
 
     set_encoding('utf8');
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 All subs are exported by default.
 

--- a/lib/Test2/Tools/Event.pm
+++ b/lib/Test2/Tools/Event.pm
@@ -6,8 +6,21 @@ our $VERSION = '0.000059';
 
 use Test2::Util qw/pkg_to_file/;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/gen_event/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 sub gen_event {
     my ($type, %fields) = @_;

--- a/lib/Test2/Tools/Event.pm
+++ b/lib/Test2/Tools/Event.pm
@@ -51,7 +51,52 @@ Test2::Tools::Event - Tools for generating test events.
 This module provides tools for generating events quickly by bypassing the
 context/hub. This is particularly useful when testing other L<Test2> packages.
 
+=head1 SYNOPSIS
+
+    use Test2::Tools::Event ':v2';
+
+    my $event = gen_event Ok => ( pass => 1, name => 'foo' );
+
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
 
 =over 4
 

--- a/lib/Test2/Tools/Exception.pm
+++ b/lib/Test2/Tools/Exception.pm
@@ -6,8 +6,21 @@ our $VERSION = '0.000059';
 
 use Test2::API qw/context/;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/dies lives try_ok/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 sub dies(&) {
     my $code = shift;

--- a/lib/Test2/Tools/Exception.pm
+++ b/lib/Test2/Tools/Exception.pm
@@ -91,7 +91,7 @@ similar to L<Test::Fatal>, but it intentionally does much less.
 
 =head1 SYNOPSIS
 
-    use Test2::Tools::Exception qw/dies lives/;
+    use Test2::Tools::Exception '+v2' => [qw/dies lives/];
 
     like(
         dies { die 'xxx' },
@@ -102,6 +102,46 @@ similar to L<Test::Fatal>, but it intentionally does much less.
     ok(lives { ... }, "did not die") or note($@);
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 All subs are exported by default.
 

--- a/lib/Test2/Tools/Exports.pm
+++ b/lib/Test2/Tools/Exports.pm
@@ -81,13 +81,53 @@ namespace.
 
 =head1 SYNOPSIS
 
-    use Test2::Tools::Exports
+    use Test2::Tools::Exports ':v2';
 
     use Data::Dumper;
     imported_ok qw/Dumper/;
     not_imported_ok qw/dumper/;
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 All subs are exported by default.
 

--- a/lib/Test2/Tools/Exports.pm
+++ b/lib/Test2/Tools/Exports.pm
@@ -8,8 +8,21 @@ use Carp qw/croak carp/;
 use Test2::API qw/context/;
 use Test2::Util::Stash qw/get_symbol/;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/imported_ok not_imported_ok/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 sub imported_ok {
     my $ctx     = context();

--- a/lib/Test2/Tools/Grab.pm
+++ b/lib/Test2/Tools/Grab.pm
@@ -44,7 +44,7 @@ Once the object is destroyed events will once again be sent to the main hub.
 
 =head1 SYNOPSIS
 
-    use Test2::Tools::Grab;
+    use Test2::Tools::Grab ':v2';
 
     my $grab = grab();
 
@@ -61,6 +61,46 @@ Once the object is destroyed events will once again be sent to the main hub.
     my $events_b = $grab->finish;
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 =over 4
 

--- a/lib/Test2/Tools/Grab.pm
+++ b/lib/Test2/Tools/Grab.pm
@@ -6,8 +6,21 @@ our $VERSION = '0.000059';
 
 use Test2::Util::Grabber;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/grab/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 sub grab { Test2::Util::Grabber->new() }
 

--- a/lib/Test2/Tools/Mock.pm
+++ b/lib/Test2/Tools/Mock.pm
@@ -320,6 +320,8 @@ plugins in ways L<Mock::Quick> would be unable to.
 
 =head1 SYNOPSIS
 
+    use Test2::Tools::Mock ':v2';
+
     my $mock = mock 'Some::Class' => (
         add => [
             new_method => sub { ... },
@@ -337,6 +339,46 @@ plugins in ways L<Mock::Quick> would be unable to.
     $mock = undef; # Undoes all the mocking, restoring all original methods.
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 =head2 DEFAULT
 

--- a/lib/Test2/Tools/Mock.pm
+++ b/lib/Test2/Tools/Mock.pm
@@ -9,7 +9,8 @@ use Test2::Util::Sub qw/gen_accessor gen_reader gen_writer/;
 
 use Test2::Mock();
 
-use base 'Exporter';
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
 
 our $VERSION = '0.000059';
 
@@ -23,6 +24,18 @@ our @EXPORT_OK = qw{
     mock_setter   mock_setters
     mock_building
 };
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_ok     => \@EXPORT_OK,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 my %HANDLERS;
 my %MOCKS;

--- a/lib/Test2/Tools/Ref.pm
+++ b/lib/Test2/Tools/Ref.pm
@@ -8,8 +8,21 @@ use Scalar::Util qw/reftype refaddr/;
 use Test2::API qw/context/;
 use Test2::Util::Ref qw/render_ref/;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/ref_ok ref_is ref_is_not/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 sub ref_ok($;$$) {
     my ($thing, $wanttype, $name) = @_;

--- a/lib/Test2/Tools/Ref.pm
+++ b/lib/Test2/Tools/Ref.pm
@@ -116,7 +116,7 @@ the functions in this module do deep comparisons.
 
 =head1 SYNOPSIS
 
-    use Test2::Tools::Ref;
+    use Test2::Tools::Ref ':v2';
 
     # Ensure something is a ref.
     ref_ok($ref);
@@ -129,6 +129,46 @@ the functions in this module do deep comparisons.
     ref_is_not($refa, $refb, "Not the same exact reference");
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 All subs are exported by default.
 

--- a/lib/Test2/Tools/Subtest.pm
+++ b/lib/Test2/Tools/Subtest.pm
@@ -78,7 +78,7 @@ and processes.
 
 =head2 BUFFERED
 
-    use Test2::Tools::Subtest qw/subtest_buffered/;
+    use Test2::Tools::Subtest qw/+v2 subtest_buffered/;
 
     subtest_buffered my_test => sub {
         ok(1, "subtest event A");
@@ -98,7 +98,7 @@ This will produce output like this:
 The default option is 'buffered'. If you want streamed subtests,
 the way L<Test::Builder> does it, use this:
 
-    use Test2::Tools::Subtest qw/subtest_streamed/;
+    use Test2::Tools::Subtest qw/+v2 subtest_streamed/;
 
     subtest_streamed my_test => sub {
         ok(1, "subtest event A");
@@ -121,6 +121,45 @@ block. This is not normally an issue, but can happen in rare conditions using
 eval, or script files as subtests.
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
 
 =over 4
 

--- a/lib/Test2/Tools/Subtest.pm
+++ b/lib/Test2/Tools/Subtest.pm
@@ -7,8 +7,21 @@ our $VERSION = '0.000059';
 use Test2::API qw/context run_subtest/;
 use Test2::Util qw/try/;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/subtest_streamed subtest_buffered/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 sub subtest_streamed {
     my $name = shift;

--- a/lib/Test2/Tools/Warnings.pm
+++ b/lib/Test2/Tools/Warnings.pm
@@ -81,7 +81,7 @@ warnings.
 
 =head1 SYNOPSIS
 
-    use Test2::Tools::Warnings qw/warns warning warnings no_warnings/;
+    use Test2::Tools::Warnings '+v2' => [qw/warns warning warnings no_warnings/];
 
     ok(warns { warn 'a' }, "the code warns");
     ok(!warns { 1 }, "The code does not warn");
@@ -105,6 +105,46 @@ warnings.
     );
 
 =head1 EXPORTS
+
+=head2 EXPORT PINS
+
+B<The current pin used by all of Test::Suite is C<v2>.>
+
+Export pins are how L<Test2::Suite> manages changes that could break backwords
+compatability. If we need to break backwards compatability we will do so by
+releasing a new pin. Old pins will continue to import the old functionality
+while new pins will import the new functionality.
+
+There are several ways to specify a pin:
+
+    # Import all the defaults provided by the 'v2' pin
+    use Package ':v2';
+
+    # Import foo, bar, and baz deom the v2 pin.
+    use Package '+v2' => [qw/foo bar baz/];
+
+    # Import 'foo' from the v2 pin, and import 'bar' and 'baz' from the v1 pin
+    use Package qw/+v2 foo +v1 bar baz/;
+
+If you do not specify a pin the default is to use the C<v1> pin (for legacy
+reasons). When the C<$AUTHOR_TESTING> environment variable is set, importing
+without a pin will produce a warning. In the future this warning may occur
+without the environment variable being set.
+
+=head3 DIFFERENCES BETWEEN PINS
+
+=over 4
+
+=item From v1 to v2
+
+This package does not have any differences between pins C<v1> and C<v2>. This
+package has 'v2' because all Test2::Suite packages gain new pins at the same
+time for consistency.
+
+=back
+
+=head2 EXPORTED SYMBOLS
+
 
 All subs are exported by default.
 

--- a/lib/Test2/Tools/Warnings.pm
+++ b/lib/Test2/Tools/Warnings.pm
@@ -6,8 +6,21 @@ our $VERSION = '0.000059';
 
 use Test2::API qw/context/;
 
+use Test2::Util::Misc qw/deprecate_pins_before/;
+use Importer Importer => qw/import/;
+
 our @EXPORT = qw/warns warning warnings no_warnings/;
-use base 'Exporter';
+sub IMPORTER_MENU {
+    return (
+        export        => \@EXPORT,
+        export_on_use => deprecate_pins_before(2),
+        export_pins   => {
+            root_name => 'no-pin',
+            'v1'      => {inherit => 'no-pin'},
+            'v2'      => {inherit => 'v1'},
+        },
+    );
+}
 
 sub warns(&) {
     my $code = shift;

--- a/lib/Test2/Util/Misc.pm
+++ b/lib/Test2/Util/Misc.pm
@@ -15,16 +15,29 @@ sub deprecate_pins_before {
     my $exporter = caller;
 
     return sub {
+        return unless $ENV{AUTHOR_TESTING} || $ENV{T2_WARN_OLD_PINS};
         my ($caller, $pin) = @_;
 
         unless (defined($pin)) {
             warn <<"            EOT";
 Importing from $exporter without a pin is deprecated at $caller->[1] line $caller->[2].
-This can be fixed by using the 'v1' pin:
-    use $exporter ':v1';
+This can be fixed quickly by using the 'v1' pin:
+
+Change these
+
+    use $exporter;     # Default imports
+    use $exporter ...; # Custom list
+
+to these:
+
+    use $exporter ':v1';      # Default imports
+    use $exporter '+v1', ...; # Custom list
 
 Or you can use the latest pin (API may change between pins)
+
     use $exporter ':v$latest_pin';
+    use $exporter '+v$latest_pin', ...;
+
             EOT
             return;
         }

--- a/lib/Test2/Util/Misc.pm
+++ b/lib/Test2/Util/Misc.pm
@@ -1,0 +1,41 @@
+package Test2::Util::Misc;
+use strict;
+use warnings;
+
+use Importer Importer => qw/import/;
+
+sub IMPORTER_MENU {
+    return (
+        export => [qw/deprecate_pins_before/],
+    );
+}
+
+sub deprecate_pins_before {
+    my $latest_pin = shift;
+    my $exporter = caller;
+
+    return sub {
+        my ($caller, $pin) = @_;
+
+        unless (defined($pin)) {
+            warn <<"            EOT";
+Importing from $exporter without a pin is deprecated at $caller->[1] line $caller->[2].
+This can be fixed by using the 'v1' pin:
+    use $exporter ':v1';
+
+Or you can use the latest pin (API may change between pins)
+    use $exporter ':v$latest_pin';
+            EOT
+            return;
+        }
+
+        return unless $ENV{T2_WARN_OLD_PINS};
+        return unless defined $latest_pin;
+        return unless $pin =~ m/^v(\d+)$/;
+        return if $1 >= $latest_pin;
+
+        warn "Importing from $exporter using old pin $pin, latest pin is v$latest_pin at $caller->[1] line $caller->[2].\n";
+    };
+}
+
+1;

--- a/lib/Test2/Util/Misc.pm
+++ b/lib/Test2/Util/Misc.pm
@@ -15,6 +15,7 @@ sub deprecate_pins_before {
     my $exporter = caller;
 
     return sub {
+        return if $ENV{T2_NO_PIN_CHECK};
         return unless $ENV{AUTHOR_TESTING} || $ENV{T2_WARN_OLD_PINS};
         my ($caller, $pin) = @_;
 

--- a/t/00-report.t
+++ b/t/00-report.t
@@ -1,4 +1,4 @@
-use Test2::Tools::Basic;
+use Test2::Tools::Basic ':v2';
 use Test2::Util::Table qw/table/;
 
 use Test2::Util qw/CAN_FORK CAN_REALLY_FORK CAN_THREAD/;

--- a/t/modules/Bundle.t
+++ b/t/modules/Bundle.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 use Test2::Bundle;
 

--- a/t/modules/Bundle/Extended.t
+++ b/t/modules/Bundle/Extended.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 use Test2::API qw/test2_stack/;
 use PerlIO;
 # HARNESS-NO-FORMATTER
@@ -37,9 +37,10 @@ ok(Test2::Plugin::ExitSummary->active, "Exit Summary is loaded");
 ok(defined(Test2::Plugin::SRand->seed), "SRand is loaded");
 
 subtest strictures => sub {
+    no warnings 'redefine';
     local $^H;
     my $hbefore = $^H;
-    Test2::Bundle::Extended->import;
+    Test2::Bundle::Extended->import(':v2');
     my $hafter = $^H;
 
     my $strict = do { local $^H; strict->import(); $^H };
@@ -52,7 +53,7 @@ subtest strictures => sub {
 subtest warnings => sub {
     local ${^WARNING_BITS};
     my $wbefore = ${^WARNING_BITS} || '';
-    Test2::Bundle::Extended->import;
+    Test2::Bundle::Extended->import(':v2');
     my $wafter = ${^WARNING_BITS} || '';
 
     my $warnings = do { local ${^WARNING_BITS}; 'warnings'->import(); ${^WARNING_BITS} || '' };
@@ -83,14 +84,14 @@ subtest utf8 => sub {
 
 subtest "rename imports" => sub {
     package A::Consumer;
-    use Test2::Bundle::Extended ':v1', '!subtest', subtest => {-as => 'a_subtest'};
+    use Test2::Bundle::Extended qw/:v2 +v2/, '!subtest', subtest => {-as => 'a_subtest'};
     imported_ok('a_subtest');
     not_imported_ok('subtest');
 };
 
 subtest "no meta" => sub {
     package B::Consumer;
-    use Test2::Bundle::Extended '!meta';
+    use Test2::Bundle::Extended ':v2', '!meta';
     imported_ok('meta_check');
     not_imported_ok('meta');
 };

--- a/t/modules/Bundle/More.t
+++ b/t/modules/Bundle/More.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
-use Test2::Bundle::More;
-use Test2::Tools::Exports;
+use Test2::Bundle::More ':v2';
+use Test2::Tools::Exports ':v2';
 
 imported_ok qw{
     ok pass fail skip todo diag note

--- a/t/modules/Bundle/Simple.t
+++ b/t/modules/Bundle/Simple.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
-use Test2::Bundle::Simple;
-use Test2::Tools::Exports;
+use Test2::Bundle::Simple ':v2';
+use Test2::Tools::Exports ':v2';
 
 imported_ok qw/ok plan done_testing skip_all/;
 

--- a/t/modules/Compare.t
+++ b/t/modules/Compare.t
@@ -1,4 +1,4 @@
-use Test2::Tools::Defer;
+use Test2::Tools::Defer ':v2';
 use strict;
 use warnings;
 
@@ -10,11 +10,12 @@ BEGIN {
     def ok => ($INC{'Test2/Compare/Undef.pm'}, "loaded the Test2::Compare::Undef module");
 }
 
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 use Test2::API qw/intercept/;
 use Data::Dumper;
 
 use Test2::Compare qw{
+    +v2
     compare get_build push_build pop_build build
     strict_convert relaxed_convert
 };

--- a/t/modules/Compare/Array.t
+++ b/t/modules/Compare/Array.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Array';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Array';
 
 isa_ok($CLASS, 'Test2::Compare::Base');
 is($CLASS->name, '<ARRAY>', "got name");

--- a/t/modules/Compare/Bag.t
+++ b/t/modules/Compare/Bag.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Bag';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Bag';
 
 isa_ok($CLASS, 'Test2::Compare::Base');
 is($CLASS->name, '<BAG>', "got name");

--- a/t/modules/Compare/Base.t
+++ b/t/modules/Compare/Base.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Base';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Base';
 
 my $one = $CLASS->new();
 isa_ok($one, $CLASS);

--- a/t/modules/Compare/Bool.t
+++ b/t/modules/Compare/Bool.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Bool';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Bool';
 
 my $one = $CLASS->new(input => 'foo');
 is($one->name, '<TRUE (foo)>', "Got name");

--- a/t/modules/Compare/Custom.t
+++ b/t/modules/Compare/Custom.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Custom';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Custom';
 
 my $pass = $CLASS->new(code => sub { 1 });
 my $fail = $CLASS->new(code => sub { 0 });

--- a/t/modules/Compare/Delta.t
+++ b/t/modules/Compare/Delta.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Delta';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Delta';
 
 can_ok($CLASS, qw/check/);
 is(

--- a/t/modules/Compare/Event.t
+++ b/t/modules/Compare/Event.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Event';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Event';
 
 my $one = $CLASS->new(etype => 'Ok');
 is($one->name, '<EVENT: Ok>', "got name");

--- a/t/modules/Compare/EventMeta.t
+++ b/t/modules/Compare/EventMeta.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::EventMeta';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::EventMeta';
 
 use Test2::Util qw/get_tid/;
 

--- a/t/modules/Compare/Hash.t
+++ b/t/modules/Compare/Hash.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Hash';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Hash';
 
 subtest simple => sub {
     my $one = $CLASS->new();

--- a/t/modules/Compare/Meta.t
+++ b/t/modules/Compare/Meta.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Meta';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Meta';
 
 local *convert = Test2::Compare->can('strict_convert');
 

--- a/t/modules/Compare/Number.t
+++ b/t/modules/Compare/Number.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Number';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Number';
 
 my $num    = $CLASS->new(input => '22.0');
 my $untrue = $CLASS->new(input => 0);

--- a/t/modules/Compare/Object.t
+++ b/t/modules/Compare/Object.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Object';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Object';
 
 subtest simple => sub {
     my $one = $CLASS->new;

--- a/t/modules/Compare/OrderedSubset.t
+++ b/t/modules/Compare/OrderedSubset.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::OrderedSubset';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::OrderedSubset';
 
 isa_ok($CLASS, 'Test2::Compare::Base');
 is($CLASS->name, '<ORDERED SUBSET>', "got name");

--- a/t/modules/Compare/Pattern.t
+++ b/t/modules/Compare/Pattern.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Pattern';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Pattern';
 
 my $one = $CLASS->new(pattern => qr/HASH/);
 isa_ok($one, $CLASS, 'Test2::Compare::Base');

--- a/t/modules/Compare/Ref.t
+++ b/t/modules/Compare/Ref.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Ref';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Ref';
 
 my $ref = sub { 1 };
 my $one = $CLASS->new(input => $ref);

--- a/t/modules/Compare/Regex.t
+++ b/t/modules/Compare/Regex.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Regex';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Regex';
 
 my $one = $CLASS->new(input => qr/abc/i);
 

--- a/t/modules/Compare/Scalar.t
+++ b/t/modules/Compare/Scalar.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Scalar';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Scalar';
 
 my $one = $CLASS->new(item => 'foo');
 is($one->name, '<SCALAR>', "got name");

--- a/t/modules/Compare/Set.t
+++ b/t/modules/Compare/Set.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Set';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Set';
 
 subtest construction => sub {
     my $one = $CLASS->new();

--- a/t/modules/Compare/String.t
+++ b/t/modules/Compare/String.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::String';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::String';
 
 my $number = $CLASS->new(input => '22.0');
 my $string = $CLASS->new(input => 'hello');

--- a/t/modules/Compare/Undef.t
+++ b/t/modules/Compare/Undef.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Undef';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Undef';
 
 my $undef = $CLASS->new();
 my $isdef = $CLASS->new(negate => 1);

--- a/t/modules/Compare/Wildcard.t
+++ b/t/modules/Compare/Wildcard.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Wildcard';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Compare::Wildcard';
 
 my $one = $CLASS->new(expect => 'foo');
 isa_ok($one, $CLASS, 'Test2::Compare::Base');

--- a/t/modules/Mock.t
+++ b/t/modules/Mock.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Mock';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Mock';
 use Test2::API qw/context/;
 
 use Scalar::Util qw/blessed/;

--- a/t/modules/Plugin.t
+++ b/t/modules/Plugin.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 use Test2::Plugin;
 

--- a/t/modules/Plugin/BailOnFail.t
+++ b/t/modules/Plugin/BailOnFail.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 use Test2::Plugin::BailOnFail;
 

--- a/t/modules/Plugin/DieOnFail.t
+++ b/t/modules/Plugin/DieOnFail.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 use Test2::Plugin::DieOnFail;
 

--- a/t/modules/Plugin/ExitSummary.t
+++ b/t/modules/Plugin/ExitSummary.t
@@ -5,9 +5,9 @@ use Test2::API;
 my $initial_count;
 BEGIN { $initial_count = Test2::API::test2_list_exit_callbacks() }
 
-use Test2::Tools::Basic;
+use Test2::Tools::Basic ':v2';
 use Test2::API qw/intercept context/;
-use Test2::Tools::Compare qw/array event end is like/;
+use Test2::Tools::Compare qw/+v2 array event end is like/;
 
 use Test2::Plugin::ExitSummary;
 use Test2::Plugin::ExitSummary;

--- a/t/modules/Plugin/SRand.t
+++ b/t/modules/Plugin/SRand.t
@@ -1,11 +1,11 @@
 use strict;
 use warnings;
 
-use Test2::Tools::Basic;
+use Test2::Tools::Basic ':v2';
 use Test2::API qw/intercept test2_stack context/;
-use Test2::Tools::Compare qw/array event end is like/;
+use Test2::Tools::Compare qw/+v2 array event end is like/;
 use Test2::Tools::Target 'Test2::Plugin::SRand';
-use Test2::Tools::Warnings qw/warning/;
+use Test2::Tools::Warnings qw/+v2 warning/;
 
 test2_stack->top;
 my ($root) = test2_stack->all;

--- a/t/modules/Plugin/UTF8.t
+++ b/t/modules/Plugin/UTF8.t
@@ -3,7 +3,7 @@ use warnings;
 # HARNESS-NO-FORMATTER
 
 use Test2::Plugin::UTF8;
-use Test2::Tools::Basic qw/ok done_testing/;
+use Test2::Tools::Basic qw/+v2 ok done_testing/;
 
 use PerlIO;
 

--- a/t/modules/Require.t
+++ b/t/modules/Require.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 use Test2::Require;
 pass "Loaded Test2::Require";

--- a/t/modules/Require/AuthorTesting.t
+++ b/t/modules/Require/AuthorTesting.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Require::AuthorTesting';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Require::AuthorTesting';
 
 {
     local %ENV = %ENV;

--- a/t/modules/Require/EnvVar.t
+++ b/t/modules/Require/EnvVar.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Require::EnvVar';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Require::EnvVar';
 
 {
     local %ENV = %ENV;

--- a/t/modules/Require/Fork.t
+++ b/t/modules/Require/Fork.t
@@ -9,7 +9,7 @@ BEGIN {
     *Test2::Util::CAN_FORK = sub { $forks };
 }
 
-use Test2::Bundle::Extended -target => 'Test2::Require::Fork';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Require::Fork';
 
 {
     $forks = 0;

--- a/t/modules/Require/Module.t
+++ b/t/modules/Require/Module.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Require::Module';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Require::Module';
 
 is($CLASS->skip('Scalar::Util'), undef, "will not skip, module installed");
 is($CLASS->skip('Scalar::Util', 0.5), undef, "will not skip, module at sufficient version");

--- a/t/modules/Require/Perl.t
+++ b/t/modules/Require/Perl.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Require::Perl';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Require::Perl';
 
 is($CLASS->skip('v5.6'), undef, "will not skip");
 is($CLASS->skip('v10.10'), 'Perl v10.10.0 required', "will skip");

--- a/t/modules/Require/RealFork.t
+++ b/t/modules/Require/RealFork.t
@@ -9,7 +9,7 @@ BEGIN {
     *Test2::Util::CAN_REALLY_FORK = sub { $forks };
 }
 
-use Test2::Bundle::Extended -target => 'Test2::Require::RealFork';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Require::RealFork';
 
 {
     $forks = 0;

--- a/t/modules/Require/Threads.t
+++ b/t/modules/Require/Threads.t
@@ -9,7 +9,7 @@ BEGIN {
     *Test2::Util::CAN_THREAD = sub { $threads };
 }
 
-use Test2::Bundle::Extended -target => 'Test2::Require::Threads';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Require::Threads';
 
 {
     $threads = 0;

--- a/t/modules/Suite.t
+++ b/t/modules/Suite.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 use Test2::Suite;
 

--- a/t/modules/Todo.t
+++ b/t/modules/Todo.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Todo';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Todo';
 
 my $todo = Test2::Todo->new(reason => 'xyz');
 def isa_ok => ($todo, $CLASS);

--- a/t/modules/Tools.t
+++ b/t/modules/Tools.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 use Test2::Tools;
 

--- a/t/modules/Tools/Basic.t
+++ b/t/modules/Tools/Basic.t
@@ -1,8 +1,8 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Basic';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Basic';
 
 {
     package Temp;
-    use Test2::Tools::Basic;
+    use Test2::Tools::Basic ':v2';
 
     main::imported_ok(qw{
         ok pass fail diag note todo skip

--- a/t/modules/Tools/Class.t
+++ b/t/modules/Tools/Class.t
@@ -1,8 +1,8 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Class';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Class';
 
 {
     package Temp;
-    use Test2::Tools::Class;
+    use Test2::Tools::Class ':v2';
 
     main::imported_ok(qw/can_ok isa_ok DOES_ok/);
 }

--- a/t/modules/Tools/ClassicCompare.t
+++ b/t/modules/Tools/ClassicCompare.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::ClassicCompare';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::ClassicCompare';
 
 use Test2::Util::Stash qw/purge_symbol/;
 BEGIN {
@@ -11,7 +11,7 @@ BEGIN {
     not_imported_ok(qw/is is_deeply like unline isnt cmp_ok/);
 }
 
-use Test2::Tools::ClassicCompare;
+use Test2::Tools::ClassicCompare ':v2';
 
 imported_ok(qw/is is_deeply like cmp_ok unlike isnt/);
 
@@ -80,9 +80,9 @@ my $thing = bless {}, 'Foo::Bar';
 # Test cmp_ok in a seperate package so we have access to the better tools.
 package main2;
 
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 BEGIN { main::purge_symbol('&cmp_ok') }
-use Test2::Tools::ClassicCompare qw/cmp_ok/;
+use Test2::Tools::ClassicCompare qw/+v2 cmp_ok/;
 use Test2::Util::Table();
 sub table { join "\n" => Test2::Util::Table::table(@_) }
 use Test2::Util::Ref qw/render_ref/;

--- a/t/modules/Tools/ClassicCompare2.t
+++ b/t/modules/Tools/ClassicCompare2.t
@@ -1,4 +1,4 @@
-use Test2::Tools::ClassicCompare;
-use Test2::Tools::Basic;
+use Test2::Tools::ClassicCompare ':v2';
+use Test2::Tools::Basic ':v2';
 is_deeply({},{}, "deep checking works");
 done_testing;

--- a/t/modules/Tools/Compare.t
+++ b/t/modules/Tools/Compare.t
@@ -1,4 +1,5 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Compare';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Compare';
+use Test2::Tools::Compare qw/is_v1 is_v2/;
 use Test2::Util::Table();
 sub table { join "\n" => Test2::Util::Table::table(@_) }
 
@@ -25,31 +26,33 @@ subtest simple => sub {
     };
 };
 
-subtest is => sub {
+subtest $_ => sub {
+    my $it = $_;
+    my $is = __PACKAGE__->can($it);
     my $events = intercept {
-        def ok => (is(1, 1), '2 arg pass');
+        def ok => ($is->(1, 1), '2 arg pass');
 
-        def ok => (is('a', 'a', "simple pass", 'diag'), 'simple pass');
-        def ok => (!is('a', 'b', "simple fail", 'diag'), 'simple fail');
+        def ok => ($is->('a', 'a', "simple pass", 'diag'), 'simple pass');
+        def ok => (!$is->('a', 'b', "simple fail", 'diag'), 'simple fail');
 
-        def ok => (is([{'a' => 1}], [{'a' => 1}], "complex pass", 'diag'), 'complex pass');
-        def ok => (!is([{'a' => 2, 'b' => 3}], [{'a' => 1}], "complex fail", 'diag'), 'complex fail');
+        def ok => ($is->([{'a' => 1}], [{'a' => 1}], "complex pass", 'diag'), 'complex pass');
+        def ok => (!$is->([{'a' => 2, 'b' => 3}], [{'a' => 1}], "complex fail", 'diag'), 'complex fail');
 
-        def ok => (is(undef, undef), 'undef pass');
-        def ok => (!is(0, undef), 'undef fail');
+        def ok => ($is->(undef, undef), 'undef pass');
+        def ok => (!$is->(0, undef), 'undef fail');
 
         my $true  = do { bless \(my $dummy = 1), "My::Boolean" };
         my $false = do { bless \(my $dummy = 0), "My::Boolean" };
-        def ok => (is($true,  $true,  "true scalar ref is itself"),  "true scalar ref is itself");
-        def ok => (is($false, $false, "false scalar ref is itself"), "false scalar ref is itself");
+        def ok => ($is->($true,  $true,  "true scalar ref is itself"),  "true scalar ref is itself");
+        def ok => ($is->($false, $false, "false scalar ref is itself"), "false scalar ref is itself");
 
         my $x = \\"123";
-        def ok => (is($x, \\"123", "Ref-Ref check 1"), "Ref-Ref check 1");
+        def ok => ($is->($x, \\"123", "Ref-Ref check 1"), "Ref-Ref check 1");
 
         $x = \[123];
-        def ok => (is($x, \["123"], "Ref-Ref check 2"), "Ref-Ref check 2");
+        def ok => ($is->($x, \["123"], "Ref-Ref check 2"), "Ref-Ref check 2");
 
-        def ok => (!is(\$x, \\["124"], "Ref-Ref check 3"), "Ref-Ref check 3");
+        def ok => (!$is->(\$x, \\["124"], "Ref-Ref check 3"), "Ref-Ref check 3");
     };
 
     do_def;
@@ -144,7 +147,7 @@ subtest is => sub {
         },
         "Got expected events"
     );
-};
+} for qw/is is_v1 is_v2/;
 
 subtest like => sub {
     my $events = intercept {

--- a/t/modules/Tools/Compare.t
+++ b/t/modules/Tools/Compare.t
@@ -1,5 +1,5 @@
 use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Compare';
-use Test2::Tools::Compare qw/is_v1 is_v2/;
+use Test2::Tools::Compare qw/+v2 is_v1 is_v2/;
 use Test2::Util::Table();
 sub table { join "\n" => Test2::Util::Table::table(@_) }
 

--- a/t/modules/Tools/Defer.t
+++ b/t/modules/Tools/Defer.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test2::Tools::Defer;
+use Test2::Tools::Defer ':v2';
 
 my $START_LINE;
 BEGIN {
@@ -14,7 +14,7 @@ BEGIN {
     def is => ({}, [], "a hash is not an array");
 }
 
-use Test2::Bundle::Extended -target => 'Test2::Tools::Defer';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Defer';
 
 sub capture(&) {
     my $code = shift;

--- a/t/modules/Tools/Encoding.t
+++ b/t/modules/Tools/Encoding.t
@@ -1,10 +1,10 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Encoding';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Encoding';
 
 use File::Temp qw/tempfile/;
 
 {
     package Temp;
-    use Test2::Tools::Encoding;
+    use Test2::Tools::Encoding ':v2';
 
     main::imported_ok(qw/set_encoding/);
 }

--- a/t/modules/Tools/Event.t
+++ b/t/modules/Tools/Event.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 imported_ok('gen_event');
 

--- a/t/modules/Tools/Exception.t
+++ b/t/modules/Tools/Exception.t
@@ -1,8 +1,8 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Exception';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Exception';
 
 {
     package Foo;
-    use Test2::Tools::Exception qw/dies lives try_ok/;
+    use Test2::Tools::Exception qw/+v2 dies lives try_ok/;
     ::imported_ok(qw/dies lives try_ok/);
 }
 

--- a/t/modules/Tools/Exports.t
+++ b/t/modules/Tools/Exports.t
@@ -1,8 +1,8 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Exports';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Exports';
 
 {
     package Temp;
-    use Test2::Tools::Exports;
+    use Test2::Tools::Exports ':v2';
 
     imported_ok(qw/imported_ok not_imported_ok/);
     not_imported_ok(qw/xyz/);

--- a/t/modules/Tools/Grab.t
+++ b/t/modules/Tools/Grab.t
@@ -1,6 +1,6 @@
-use Test2::Bundle::Extended -target => 'Test2::Util::Grabber';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Util::Grabber';
 
-use Test2::Tools::Grab;
+use Test2::Tools::Grab ':v2';
 
 ok(1, "initializing");
 

--- a/t/modules/Tools/Mock.t
+++ b/t/modules/Tools/Mock.t
@@ -1,6 +1,7 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Custom';
+use Test2::Bundle::Extended -target => 'Test2::Compare::Custom', ':v2';
 
 use Test2::Tools::Mock qw{
+    +v2
     mock_obj mock_class
     mock_do  mock_build
     mock_accessor mock_accessors

--- a/t/modules/Tools/Ref.t
+++ b/t/modules/Tools/Ref.t
@@ -1,8 +1,8 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Ref';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Ref';
 
 {
     package Temp;
-    use Test2::Tools::Ref;
+    use Test2::Tools::Ref ':v2';
 
     main::imported_ok(qw/ref_ok ref_is ref_is_not/);
 }

--- a/t/modules/Tools/Subtest.t
+++ b/t/modules/Tools/Subtest.t
@@ -1,6 +1,6 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Subtest';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Subtest';
 
-use Test2::Tools::Subtest qw/subtest_streamed subtest_buffered/;
+use Test2::Tools::Subtest qw/+v2 subtest_streamed subtest_buffered/;
 
 
 use File::Temp qw/tempfile/;
@@ -14,7 +14,7 @@ if ($] > 5.020000) {
             subtest_streamed 'foo' => sub {
                 my ($fh, $name) = tempfile;
                 print $fh <<"                EOT";
-                    use Test2::Bundle::Extended;
+                    use Test2::Bundle::Extended ':v2';
                     BEGIN { skip_all 'because' }
                     1;
                 EOT

--- a/t/modules/Tools/Target.t
+++ b/t/modules/Tools/Target.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v1';
 
 use Test2::Tools::Target 'Test2::Tools::Target';
 

--- a/t/modules/Tools/Warnings.t
+++ b/t/modules/Tools/Warnings.t
@@ -1,8 +1,8 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Warnings';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Tools::Warnings';
 
 {
     package Foo;
-    use Test2::Tools::Warnings qw/warns warning warnings no_warnings/;
+    use Test2::Tools::Warnings qw/+v2 warns warning warnings no_warnings/;
     ::imported_ok(qw/warns warning warnings no_warnings/);
 }
 

--- a/t/modules/Util/Grabber.t
+++ b/t/modules/Util/Grabber.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Util::Grabber';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Util::Grabber';
 
 ok(1, "initializing");
 

--- a/t/modules/Util/Misc.t
+++ b/t/modules/Util/Misc.t
@@ -1,0 +1,43 @@
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Util::Misc';
+
+use Test2::Util::Misc qw/deprecate_pins_before/;
+
+imported_ok qw/deprecate_pins_before/;
+
+my $sub = deprecate_pins_before(5);
+ref_ok($sub, 'CODE', "Got a code ref");
+
+my $caller = [ __PACKAGE__, 'a_file', 42 ];
+
+ok(!warning { $sub->($caller, 'v5') }, "No warnings when using latest pin");
+
+ok(!warning { $sub->($caller, 'v1') }, "No warnings when using older pin");
+
+like(
+    warning { $sub->($caller, undef) },
+    <<"    EOT",
+Importing from main without a pin is deprecated at a_file line 42.
+This can be fixed by using the 'v1' pin:
+    use main ':v1';
+
+Or you can use the latest pin (API may change between pins)
+    use main ':v5';
+    EOT
+    "Got warning with no pin"
+);
+
+{
+    local $ENV{T2_WARN_OLD_PINS} = 1;
+
+    ok(!warning { $sub->($caller, 'v5') }, "No warnings when using latest pin");
+
+    like(
+        warning { $sub->($caller, 'v4') },
+        "Importing from main using old pin v4, latest pin is v5 at a_file line 42.\n",
+        "Can ask to warn about old pins",
+    );
+
+    ok(!warning { $sub->($caller, 'xyz') }, "No warnings when using non-version pin");
+}
+
+done_testing;

--- a/t/modules/Util/Misc.t
+++ b/t/modules/Util/Misc.t
@@ -1,6 +1,7 @@
 use Test2::Bundle::Extended ':v2', -target => 'Test2::Util::Misc';
 
 local $ENV{T2_WARN_OLD_PINS} = 0;
+local $ENV{AUTHOR_TESTING} = 1;
 
 use Test2::Util::Misc qw/deprecate_pins_before/;
 

--- a/t/modules/Util/Misc.t
+++ b/t/modules/Util/Misc.t
@@ -1,5 +1,7 @@
 use Test2::Bundle::Extended ':v2', -target => 'Test2::Util::Misc';
 
+local $ENV{T2_WARN_OLD_PINS} = 0;
+
 use Test2::Util::Misc qw/deprecate_pins_before/;
 
 imported_ok qw/deprecate_pins_before/;
@@ -17,11 +19,23 @@ like(
     warning { $sub->($caller, undef) },
     <<"    EOT",
 Importing from main without a pin is deprecated at a_file line 42.
-This can be fixed by using the 'v1' pin:
-    use main ':v1';
+This can be fixed quickly by using the 'v1' pin:
+
+Change these
+
+    use main;     # Default imports
+    use main ...; # Custom list
+
+to these:
+
+    use main ':v1';      # Default imports
+    use main '+v1', ...; # Custom list
 
 Or you can use the latest pin (API may change between pins)
+
     use main ':v5';
+    use main '+v5', ...;
+
     EOT
     "Got warning with no pin"
 );

--- a/t/modules/Util/Ref.t
+++ b/t/modules/Util/Ref.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 use Test2::Util::Ref qw/rtype render_ref/;
 

--- a/t/modules/Util/Stash.t
+++ b/t/modules/Util/Stash.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended -target => 'Test2::Util::Stash';
+use Test2::Bundle::Extended ':v2', -target => 'Test2::Util::Stash';
 
 use Test2::Util::Stash qw{
     get_stash

--- a/t/modules/Util/Sub.t
+++ b/t/modules/Util/Sub.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 use Test2::Util::Sub qw{
     sub_info

--- a/t/modules/Util/Table.t
+++ b/t/modules/Util/Table.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 use Test2::Util::Table qw/table term_size/;
 
 imported_ok qw/table term_size/;

--- a/t/modules/Util/Table/LineBreak.t
+++ b/t/modules/Util/Table/LineBreak.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 use Test2::Util::Table::LineBreak;
 
 subtest with_unicode_linebreak => sub {

--- a/t/regression/10-set_and_dne.t
+++ b/t/regression/10-set_and_dne.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 my $check = hash {
   field first   => 42;

--- a/t/regression/27-1-Test2-Bundle-More.t
+++ b/t/regression/27-1-Test2-Bundle-More.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::More;
+use Test2::Bundle::More ':v2';
 use strict;
 use warnings;
 

--- a/t/regression/27-2-Test2-Tools-Compare.t
+++ b/t/regression/27-2-Test2-Tools-Compare.t
@@ -1,4 +1,4 @@
-use Test2::Tools::Compare;
+use Test2::Tools::Compare ':v2';
 use strict;
 use warnings;
 

--- a/t/regression/27-3-Test2-Tools-ClassicCompare.t
+++ b/t/regression/27-3-Test2-Tools-ClassicCompare.t
@@ -1,4 +1,4 @@
-use Test2::Tools::ClassicCompare;
+use Test2::Tools::ClassicCompare ':v2';
 use strict;
 use warnings;
 

--- a/t/regression/43-bag-on-empty.t
+++ b/t/regression/43-bag-on-empty.t
@@ -1,4 +1,4 @@
-use Test2::Bundle::Extended;
+use Test2::Bundle::Extended ':v2';
 
 my $got = intercept {
     my $check = bag {

--- a/t/v1/Bundle/Extended.t
+++ b/t/v1/Bundle/Extended.t
@@ -1,0 +1,101 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended;
+use Test2::API qw/test2_stack/;
+use PerlIO;
+# HARNESS-NO-FORMATTER
+
+imported_ok qw{
+    ok pass fail diag note todo skip
+    plan skip_all done_testing bail_out
+
+    gen_event
+
+    intercept context
+
+    cmp_ok
+
+    subtest
+    can_ok isa_ok DOES_ok
+    set_encoding
+    imported_ok not_imported_ok
+    ref_ok ref_is ref_is_not
+    mock mocked
+
+    dies lives try_ok
+
+    is like isnt unlike
+    match mismatch validator
+    hash array object meta number string bool
+    in_set not_in_set check_set
+    item field call call_list call_hash prop check all_items all_keys all_vals all_values
+    etc end filter_items
+    T F D DF E DNE FDNE U
+    event fail_events
+    exact_ref
+};
+
+ok(Test2::Plugin::ExitSummary->active, "Exit Summary is loaded");
+ok(defined(Test2::Plugin::SRand->seed), "SRand is loaded");
+
+subtest strictures => sub {
+    local $^H;
+    my $hbefore = $^H;
+    Test2::Bundle::Extended->import;
+    my $hafter = $^H;
+
+    my $strict = do { local $^H; strict->import(); $^H };
+
+    ok($strict,               'sanity, got $^H value for strict');
+    ok(!($hbefore & $strict), "strict is not on before loading Test2::Bundle::Extended");
+    ok(($hafter & $strict),   "strict is on after loading Test2::Bundle::Extended");
+};
+
+subtest warnings => sub {
+    local ${^WARNING_BITS};
+    my $wbefore = ${^WARNING_BITS} || '';
+    Test2::Bundle::Extended->import;
+    my $wafter = ${^WARNING_BITS} || '';
+
+    my $warnings = do { local ${^WARNING_BITS}; 'warnings'->import(); ${^WARNING_BITS} || '' };
+
+    ok($warnings, 'sanity, got ${^WARNING_BITS} value for warnings');
+    ok($wbefore ne $warnings, "warnings are not on before loading Test2::Bundle::Extended") || diag($wbefore, "\n", $warnings);
+    ok(($wafter & $warnings), "warnings are on after loading Test2::Bundle::Extended");
+};
+
+subtest utf8 => sub {
+    ok(utf8::is_utf8("癸"), "utf8 pragma is on");
+
+    my $layers = { map {$_ => 1} PerlIO::get_layers(STDERR) };
+    ok($layers->{utf8}, "utf8 is on for STDERR");
+
+    $layers = { map {$_ => 1} PerlIO::get_layers(STDOUT) };
+    ok($layers->{utf8}, "utf8 is on for STDOUT");
+
+    # -2 cause the subtest adds to the stack
+    my $format = test2_stack()->[-2]->format;
+    my $handles = $format->handles;
+    for my $hn (0 .. @$handles) {
+        my $h = $handles->[$hn] || next;
+        $layers = { map {$_ => 1} PerlIO::get_layers($h) };
+        ok($layers->{utf8}, "utf8 is on for formatter handle $hn");
+    }
+};
+
+subtest "rename imports" => sub {
+    package A::Consumer;
+    use Test2::Bundle::Extended ':v1', '!subtest', subtest => {-as => 'a_subtest'};
+    imported_ok('a_subtest');
+    not_imported_ok('subtest');
+};
+
+subtest "no meta" => sub {
+    package B::Consumer;
+    use Test2::Bundle::Extended '!meta';
+    imported_ok('meta_check');
+    not_imported_ok('meta');
+};
+
+done_testing;
+
+1;

--- a/t/v1/Bundle/More.t
+++ b/t/v1/Bundle/More.t
@@ -1,0 +1,24 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use strict;
+use warnings;
+use Test2::Bundle::More;
+use Test2::Tools::Exports;
+
+imported_ok qw{
+    ok pass fail skip todo diag note
+    plan skip_all done_testing BAIL_OUT
+
+    is isnt like unlike is_deeply cmp_ok isa_ok
+
+    can_ok
+    subtest
+};
+
+ok(Test2::Plugin::ExitSummary->active, "Exit Summary is loaded");
+
+done_testing;
+
+1;
+
+__END__
+

--- a/t/v1/Bundle/Simple.t
+++ b/t/v1/Bundle/Simple.t
@@ -1,0 +1,16 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use strict;
+use warnings;
+use Test2::Bundle::Simple;
+use Test2::Tools::Exports;
+
+imported_ok qw/ok plan done_testing skip_all/;
+
+ok(Test2::Plugin::ExitSummary->active, "Exit Summary is loaded");
+
+done_testing;
+
+1;
+
+__END__
+

--- a/t/v1/Tools/Basic.t
+++ b/t/v1/Tools/Basic.t
@@ -1,0 +1,305 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Tools::Basic';
+
+{
+    package Temp;
+    use Test2::Tools::Basic;
+
+    main::imported_ok(qw{
+        ok pass fail diag note todo skip
+        plan skip_all done_testing bail_out
+    });
+}
+
+pass('Testing Pass');
+
+my @lines;
+like(
+    intercept {
+        pass('pass');               push @lines => __LINE__;
+        fail('fail');               push @lines => __LINE__;
+        fail('fail', 'added diag'); push @lines => __LINE__;
+    },
+    array {
+        event Ok => sub {
+            call pass => 1;
+            call name => 'pass';
+
+            prop file    => __FILE__;
+            prop package => __PACKAGE__;
+            prop line    => $lines[0];
+            prop subname => 'Test2::Tools::Basic::pass';
+        };
+
+        event Ok => sub {
+            call pass => 0;
+            call name => 'fail';
+
+            prop file    => __FILE__;
+            prop package => __PACKAGE__;
+            prop line    => $lines[1];
+            prop subname => 'Test2::Tools::Basic::fail';
+        };
+        event Diag => sub {
+            call message => qr/Failed test 'fail'.*line $lines[1]/s;
+
+            prop file    => __FILE__;
+            prop package => __PACKAGE__;
+            prop line    => $lines[1];
+            prop subname => 'Test2::Tools::Basic::fail';
+        };
+
+        event Ok => sub {
+            call pass => 0;
+            call name => 'fail';
+
+            prop file    => __FILE__;
+            prop package => __PACKAGE__;
+            prop line    => $lines[2];
+            prop subname => 'Test2::Tools::Basic::fail';
+        };
+        event Diag => sub {
+            call message => qr/Failed test 'fail'.*line $lines[2]/s;
+
+            prop file    => __FILE__;
+            prop package => __PACKAGE__;
+            prop line    => $lines[2];
+            prop subname => 'Test2::Tools::Basic::fail';
+        };
+        event Diag => sub {
+            call message => 'added diag';
+
+            prop file    => __FILE__;
+            prop package => __PACKAGE__;
+            prop line    => $lines[2];
+            prop subname => 'Test2::Tools::Basic::fail';
+        };
+
+        end;
+    },
+    "Got expected events for 'pass' and 'fail'"
+);
+
+ok(1, 'Testing ok');
+
+@lines = ();
+like(
+    intercept {
+        ok(1, 'pass', 'invisible diag'); push @lines => __LINE__;
+        ok(0, 'fail');                   push @lines => __LINE__;
+        ok(0, 'fail', 'added diag');     push @lines => __LINE__;
+    },
+    array {
+        event Ok => sub {
+            call pass => 1;
+            call name => 'pass';
+            prop line => $lines[0];
+        };
+
+        event Ok => sub {
+            call pass => 0;
+            call name => 'fail';
+            prop debug => 'at ' . __FILE__ . " line $lines[1]";
+        };
+        event Diag => sub {
+            call message => qr/Failed test 'fail'.*line $lines[1]/s;
+            prop debug => 'at ' . __FILE__ . " line $lines[1]";
+        };
+
+        event Ok => sub {
+            call pass => 0;
+            call name => 'fail';
+            prop debug => 'at ' . __FILE__ . " line $lines[2]";
+        };
+        event Diag => sub {
+            call message => qr/Failed test 'fail'.*line $lines[2]/s;
+            prop debug => 'at ' . __FILE__ . " line $lines[2]";
+        };
+        event Diag => sub {
+            call message => 'added diag';
+            prop debug => 'at ' . __FILE__ . " line $lines[2]";
+        };
+
+        end;
+    },
+    "Got expected events for 'ok'"
+);
+
+diag "Testing Diag (AUTHOR_TESTING ONLY)" if $ENV{AUTHOR_TESTING};
+
+like(
+    intercept {
+        diag "foo";
+        diag "foo", ' ', "bar";
+    },
+    array {
+        event Diag => { message => 'foo' };
+        event Diag => { message => 'foo bar' };
+    },
+    "Got expected events for diag"
+);
+
+note "Testing Note";
+
+like(
+    intercept {
+        note "foo";
+        note "foo", ' ', "bar";
+    },
+    array {
+        event Note => { message => 'foo' };
+        event Note => { message => 'foo bar' };
+    },
+    "Got expected events for note"
+);
+
+like(
+    intercept {
+        bail_out 'oops';
+        # Should not get here
+        print STDERR "Something is wrong, did not bail out!\n";
+        exit 255;
+    },
+    array {
+        event Bail => { reason => 'oops' };
+        end;
+    },
+    "Got bail event"
+);
+
+like(
+    intercept {
+        skip_all 'oops';
+        # Should not get here
+        print STDERR "Something is wrong, did not skip!\n";
+        exit 255;
+    },
+    array {
+        event Plan => { max => 0, directive => 'SKIP', reason => 'oops' };
+        end;
+    },
+    "Got plan (skip_all) event"
+);
+
+like(
+    intercept {
+        plan skip_all => 'oops';
+        # Should not get here
+        print STDERR "Something is wrong, did not skip!\n";
+        exit 255;
+    },
+    array {
+        event Plan => { max => 0, directive => 'SKIP', reason => 'oops' };
+        end;
+    },
+    "Got plan 'skip_all' prefix"
+);
+
+
+like(
+    intercept {
+        plan(5);
+    },
+    array {
+        event Plan => { max => 5 };
+        end;
+    },
+    "Got plan"
+);
+
+like(
+    intercept {
+        plan(tests => 5);
+    },
+    array {
+        event Plan => { max => 5 };
+        end;
+    },
+    "Got plan 'tests' prefix"
+);
+
+
+like(
+    intercept {
+        ok(1);
+        ok(2);
+        done_testing;
+    },
+    array {
+        event Ok => { pass => 1 };
+        event Ok => { pass => 1 };
+        event Plan => { max => 2 };
+        end;
+    },
+    "Done Testing works"
+);
+
+like(
+    intercept {
+        ok(0, "not todo");
+
+        {
+            my $todo = todo('todo 1');
+            ok(0, 'todo fail');
+        }
+
+        ok(0, "not todo");
+
+        my $todo = todo('todo 2');
+        ok(0, 'todo fail');
+        $todo = undef;
+
+        ok(0, "not todo");
+
+        todo 'todo 3' => sub {
+            ok(0, 'todo fail');
+        };
+
+        ok(0, "not todo");
+    },
+    array {
+        for my $id (1 .. 3) {
+            event Ok => sub {
+                call pass => 0;
+                call effective_pass => 0;
+                call todo => undef;
+            };
+            event Diag => { message => qr/Failed/ };
+
+            event Ok => sub {
+                call pass => 0;
+                call effective_pass => 1;
+                call todo => "todo $id";
+            };
+            event Note => { message => qr/Failed/ };
+        }
+        event Ok => { pass => 0, effective_pass => 0 };
+        event Diag => { message => qr/Failed/ };
+        end;
+    },
+    "Got todo events"
+);
+
+like(
+    intercept {
+        ok(1, 'pass');
+        SKIP: {
+            skip 'oops' => 5;
+
+            ok(1, "Should not see this");
+        }
+    },
+    array {
+        event Ok => { pass => 1 };
+
+        event Skip => sub {
+            call pass => 1;
+            call reason => 'oops';
+        } for 1 .. 5;
+
+        end;
+    },
+    "got skip events"
+);
+
+done_testing;

--- a/t/v1/Tools/Class.t
+++ b/t/v1/Tools/Class.t
@@ -1,0 +1,153 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Tools::Class';
+
+{
+    package Temp;
+    use Test2::Tools::Class;
+
+    main::imported_ok(qw/can_ok isa_ok DOES_ok/);
+}
+
+{
+    package X;
+
+    sub can {
+        my $thing = pop;
+        return 1 if $thing =~ m/x/;
+        return 1 if $thing eq 'DOES';
+    }
+
+    sub isa {
+        my $thing = pop;
+        return 1 if $thing =~ m/x/;
+    }
+
+    sub DOES {
+        my $thing = pop;
+        return 1 if $thing =~ m/x/;
+    }
+}
+
+{
+    package XYZ;
+    use Carp qw/croak/;
+    sub isa { croak 'oops' };
+    sub can { croak 'oops' };
+    sub DOES { croak 'oops' };
+}
+
+{
+    package My::String;
+    use overload '""' => sub { "xxx\nyyy" };
+
+    sub DOES { 0 }
+}
+
+like(
+    intercept {
+        my $str = bless {}, 'My::String';
+
+        isa_ok('X', qw/axe box fox/);
+        can_ok('X', qw/axe box fox/);
+        DOES_ok('X', qw/axe box fox/);
+        isa_ok($str, 'My::String');
+
+        isa_ok('X',  qw/foo bar axe box/);
+        can_ok('X',  qw/foo bar axe box/);
+        DOES_ok('X', qw/foo bar axe box/);
+
+        isa_ok($str, 'X');
+        can_ok($str, 'X');
+        DOES_ok($str, 'X');
+
+        isa_ok(undef, 'X');
+        isa_ok('', 'X');
+        isa_ok({}, 'X');
+
+        isa_ok('X',  [qw/axe box fox/], 'alt name');
+        can_ok('X',  [qw/axe box fox/], 'alt name');
+        DOES_ok('X', [qw/axe box fox/], 'alt name');
+
+        isa_ok('X',  [qw/foo bar axe box/], 'alt name');
+        can_ok('X',  [qw/foo bar axe box/], 'alt name');
+        DOES_ok('X', [qw/foo bar axe box/], 'alt name');
+    },
+    array {
+        event Ok => { pass => 1, name => 'X->isa(...)' };
+        event Ok => { pass => 1, name => 'X->can(...)' };
+        event Ok => { pass => 1, name => 'X->DOES(...)' };
+        event Ok => { pass => 1, name => qr/My::String=.*->isa\('My::String'\)/ };
+
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => {message => "Failed: X->isa('foo')"};
+        event Diag => {message => "Failed: X->isa('bar')"};
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "Failed: X->can('foo')" };
+        event Diag => { message => "Failed: X->can('bar')" };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "Failed: X->DOES('foo')" };
+        event Diag => { message => "Failed: X->DOES('bar')" };
+
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => qr/Failed: My::String=HASH->isa\('X'\)/ };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => qr/Failed: My::String=HASH->can\('X'\)/ };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => qr/Failed: My::String=HASH->DOES\('X'\)/ };
+
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => qr/<undef> is neither a blessed reference or a package name/ };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => qr/'' is neither a blessed reference or a package name/ };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => qr/HASH is neither a blessed reference or a package name/ };
+
+        event Ok => { pass => 1, name => 'alt name' };
+        event Ok => { pass => 1, name => 'alt name' };
+        event Ok => { pass => 1, name => 'alt name' };
+
+        fail_events Ok => sub { call pass => 0; call name => 'alt name' };
+        event Diag => {message => "Failed: X->isa('foo')"};
+        event Diag => {message => "Failed: X->isa('bar')"};
+        fail_events Ok => sub { call pass => 0; call name => 'alt name' };
+        event Diag => {message => "Failed: X->can('foo')"};
+        event Diag => {message => "Failed: X->can('bar')"};
+        fail_events Ok => sub { call pass => 0; call name => 'alt name' };
+        event Diag => {message => "Failed: X->DOES('foo')"};
+        event Diag => {message => "Failed: X->DOES('bar')"};
+
+        end;
+    },
+    "'can/isa/DOES_ok' events"
+);
+
+my $override = UNIVERSAL->can('DOES') ? 1 : 0;
+note "Will override UNIVERSAL::can to hide 'DOES'" if $override;
+
+my $events = intercept {
+    my $can = \&UNIVERSAL::can;
+
+    # If the platform does support 'DOES' lets pretend it doesn't.
+    no warnings 'redefine';
+    local *UNIVERSAL::can = sub {
+        my ($thing, $sub) = @_;
+        return undef if $sub eq 'DOES';
+        $thing->$can($sub);
+    } if $override;
+
+    DOES_ok('A::Fake::Package', 'xxx');
+};
+
+like(
+    $events,
+    array {
+        event Skip => {
+            pass   => 1,
+            name   => "A::Fake::Package->DOES('xxx')",
+            reason => "'DOES' is not supported on this platform",
+        };
+    },
+    "Test us skipped when platform does not support 'DOES'"
+);
+
+done_testing;

--- a/t/v1/Tools/ClassicCompare.t
+++ b/t/v1/Tools/ClassicCompare.t
@@ -1,0 +1,342 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Tools::ClassicCompare';
+
+use Test2::Util::Stash qw/purge_symbol/;
+BEGIN {
+    purge_symbol('&is');
+    purge_symbol('&like');
+    purge_symbol('&unlike');
+    purge_symbol('&isnt');
+    purge_symbol('&cmp_ok');
+
+    not_imported_ok(qw/is is_deeply like unline isnt cmp_ok/);
+}
+
+use Test2::Tools::ClassicCompare;
+
+imported_ok(qw/is is_deeply like cmp_ok unlike isnt/);
+
+my $ref = {};
+
+is(undef, undef, "undef is undef");
+
+is("foo", "foo", 'foo check');
+is($ref,   "$ref", "flat check, ref as string right");
+is("$ref", $ref,   "flat check, ref as string left");
+
+isnt("bar", "foo", 'not foo check');
+isnt({},   "$ref", "negated flat check, ref as string right");
+isnt("$ref", {},   "negated flat check, ref as string left");
+
+like('aaa', qr/a/, "have an a");
+like('aaa', 'a', "have an a, not really a regex");
+
+unlike('bbb', qr/a/, "do not have an a");
+unlike('bbb', 'a', "do not have an a, not really a regex");
+
+# Failures
+my $events = intercept {
+    def ok => (!is('foo', undef, "undef check"),     "undef check");
+    def ok => (!is(undef, 'foo',   "undef check"),     "undef check");
+    def ok => (!is('foo', 'bar', "string mismatch"), "string mismatch");
+    def ok => (!isnt('foo', 'foo', "undesired match"), "undesired match");
+    def ok => (!like('foo', qr/a/, "no match"), "no match");
+    def ok => (!unlike('foo', qr/o/, "unexpected match"), "unexpected match");
+};
+
+do_def;
+
+is_deeply(
+    $events,
+    array {
+        filter_items { grep { !$_->isa('Test2::Event::Diag') } @_ };
+        event Ok => sub { field pass => 0; etc };
+        event Ok => sub { field pass => 0; etc };
+        event Ok => sub { field pass => 0; etc };
+        event Ok => sub { field pass => 0; etc };
+        event Ok => sub { field pass => 0; etc };
+        event Ok => sub { field pass => 0; etc };
+        end;
+    },
+    "got failure events"
+);
+
+# is_deeply uses the same algorithm as the 'Compare' plugin, so it is already
+# tested over there.
+is_deeply(
+    {foo => 1, bar => 'baz'},
+    {foo => 1, bar => 'baz'},
+    "Deep compare"
+);
+
+{
+    package Foo;
+    use overload '""' => sub { 'xxx' };
+}
+my $foo = bless({}, 'Foo');
+like($foo, qr/xxx/, "overload");
+
+my $thing = bless {}, 'Foo::Bar';
+
+# Test cmp_ok in a seperate package so we have access to the better tools.
+package main2;
+
+use Test2::Bundle::Extended;
+BEGIN { main::purge_symbol('&cmp_ok') }
+use Test2::Tools::ClassicCompare qw/cmp_ok/;
+use Test2::Util::Table();
+sub table { join "\n" => Test2::Util::Table::table(@_) }
+use Test2::Util::Ref qw/render_ref/;
+
+cmp_ok('x', 'eq', 'x', 'string pass');
+cmp_ok(5, '==', 5, 'number pass');
+cmp_ok(5, '==', 5.0, 'float pass');
+
+my $file = __FILE__;
+my $line = __LINE__ + 2;
+like(
+    warnings { cmp_ok(undef, '==', undef, 'undef pass') },
+    [
+        qr/uninitialized value.*at \(eval in cmp_ok\) \Q$file\E line $line/,
+    ],
+    "got expected warnings (number)"
+);
+
+$line = __LINE__ + 2;
+like(
+    warnings { cmp_ok(undef, 'eq', undef, 'undef pass') },
+    [
+        qr/uninitialized value.*at \(eval in cmp_ok\) \Q$file\E line $line/,
+    ],
+    "got expected warnings (string)"
+);
+
+like(
+    intercept { cmp_ok('x', 'ne', 'x', 'string fail', 'extra diag') },
+    array {
+        fail_events Ok => sub {
+            call pass => 0;
+            call name => 'string fail';
+        };
+        event Diag => sub {
+            call message => table(
+                header => [qw/GOT OP CHECK/],
+                rows   => [
+                    [qw/x ne x/],
+                ],
+            );
+        };
+        event Diag => { message => 'extra diag' };
+        end;
+    },
+    "Got 1 string fail event"
+);
+
+like(
+    intercept { cmp_ok(5, '==', 42, 'number fail', 'extra diag') },
+    array {
+        fail_events Ok => sub {
+            call pass => 0;
+            call name => 'number fail';
+        };
+        event Diag => sub {
+            call message => table(
+                header => [qw/GOT OP CHECK/],
+                rows   => [
+                    [qw/5 == 42/],
+                ],
+            );
+        };
+        event Diag => { message => 'extra diag' };
+
+        end;
+    },
+    "Got 1 number fail event"
+);
+
+my $warning;
+$line = __LINE__ + 2;
+like(
+    intercept { $warning = main::warning { cmp_ok(5, '&& die', 42, 'number fail', 'extra diag') } },
+    array {
+        event Exception => { error => qr/42 at \(eval in cmp_ok\) \Q$file\E line $line/ };
+        fail_events Ok => sub {
+            call pass => 0;
+            call name => 'number fail';
+        };
+
+        event Diag => sub {
+            call message => table(
+                header => [qw/GOT OP CHECK/],
+                rows   => [
+                    ['5', '&& die', '<EXCEPTION>'],
+                ],
+            );
+        };
+        event Diag => { message => 'extra diag' };
+
+        end;
+    },
+    "Got exception in test"
+);
+like(
+    $warning,
+    qr/operator '&& die' is not supported \(you can add it to %Test2::Tools::ClassicCompare::OPS\)/,
+    "Got warning about unsupported operator"
+);
+
+{
+    package Overloaded::Foo42;
+    use overload
+        'fallback' => 1,
+        '0+' => sub { 42    },
+        '""' => sub { 'foo' };
+}
+
+$foo = bless {}, 'Overloaded::Foo42';
+
+cmp_ok($foo, '==', 42, "numeric compare with overloading");
+cmp_ok($foo, 'eq', 'foo', "string compare with overloading");
+
+like(
+    intercept {
+        local $ENV{TS_TERM_SIZE} = 10000;
+        cmp_ok($foo, 'ne', $foo, 'string fail', 'extra diag')
+    },
+    array {
+        fail_events Ok => sub {
+            call pass => 0;
+            call name => 'string fail';
+        };
+
+        event Diag => sub {
+            call message => table(
+                header => [qw/TYPE GOT OP CHECK/],
+                rows   => [
+                    ['str', 'foo', 'ne', 'foo'],
+                    ['orig', render_ref($foo), '', render_ref($foo)],
+                ],
+            );
+        };
+        event Diag => { message => 'extra diag' };
+
+        end;
+    },
+    "Failed string compare, overload"
+);
+
+like(
+    intercept {
+        local $ENV{TS_TERM_SIZE} = 10000;
+        cmp_ok($foo, '!=', $foo, 'number fail', 'extra diag')
+    },
+    array {
+        fail_events Ok => sub {
+            call pass => 0;
+            call name => 'number fail';
+        };
+
+        event Diag => sub {
+            call message => table(
+                header => [qw/TYPE GOT OP CHECK/],
+                rows   => [
+                    ['num', '42', '!=', '42'],
+                    ['orig', render_ref($foo), '', render_ref($foo)],
+                ],
+            );
+        };
+        event Diag => { message => 'extra diag' };
+
+        end;
+    },
+    "Failed number compare, overload"
+);
+
+$line = __LINE__ + 2;
+like(
+    intercept {
+        local $ENV{TS_TERM_SIZE} = 10000;
+        main::warning {
+            cmp_ok($foo, '&& die', $foo, 'overload exception', 'extra diag')
+        }
+    },
+    array {
+        event Exception => { error => T() };
+        fail_events Ok => sub {
+            call pass => 0;
+            call name => 'overload exception';
+        };
+
+        event Diag => sub {
+            call message => table(
+                header => [qw/TYPE GOT OP CHECK/],
+                rows   => [
+                    ['unsupported', 'foo', '&& die', '<EXCEPTION>'],
+                    ['orig', render_ref($foo), '', render_ref($foo)],
+                ],
+            );
+        };
+        event Diag => { message => 'extra diag' };
+
+        end;
+    },
+    "Got exception in test"
+);
+
+
+note "cmp_ok() displaying good numbers"; {
+    my $have = 1.23456;
+    my $want = 4.5678;
+    like(
+        intercept {
+            cmp_ok($have, '>', $want);
+        },
+        array {
+            fail_events Ok => sub {
+                call pass => 0;
+            };
+
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK/],
+                    rows   => [
+                      [$have, '>', $want],
+                    ],
+                );
+            };
+
+            end;
+        },
+    );
+}
+
+
+note "cmp_ok() displaying bad numbers"; {
+    my $have = "zero";
+    my $want = "3point5";
+    like(
+        intercept {
+            warnings { cmp_ok($have, '>', $want) };
+        },
+        array {
+            fail_events Ok => sub {
+                call pass => 0;
+            };
+
+            event Diag => sub {
+                call message => table(
+                    header => [qw/TYPE GOT OP CHECK/],
+                    rows   => [
+                      ['num',   0,      '>',    '3'],
+                      ['orig',  $have,  '',     $want],
+                    ],
+                );
+            };
+
+            end;
+        },
+    );
+}
+
+
+done_testing;

--- a/t/v1/Tools/ClassicCompare2.t
+++ b/t/v1/Tools/ClassicCompare2.t
@@ -1,0 +1,5 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Tools::ClassicCompare;
+use Test2::Tools::Basic;
+is_deeply({},{}, "deep checking works");
+done_testing;

--- a/t/v1/Tools/Compare.t
+++ b/t/v1/Tools/Compare.t
@@ -1,0 +1,1578 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Tools::Compare';
+use Test2::Util::Table();
+sub table { join "\n" => Test2::Util::Table::table(@_) }
+
+{
+    package My::Boolean;
+    use overload bool => sub { ${$_[0]} };
+}
+
+{
+    package My::String;
+    use overload '""' => sub { "xxx" };
+}
+
+subtest simple => sub {
+    imported_ok qw{
+        match mismatch validator
+        hash array bag object meta number string bool
+        in_set not_in_set check_set
+        item field call call_list call_hash prop check all_items all_keys all_vals all_values
+        etc end filter_items
+        T F D DF E DNE FDNE U
+        event
+        exact_ref
+    };
+};
+
+subtest is => sub {
+    my $events = intercept {
+        def ok => (is(1, 1), '2 arg pass');
+
+        def ok => (is('a', 'a', "simple pass", 'diag'), 'simple pass');
+        def ok => (!is('a', 'b', "simple fail", 'diag'), 'simple fail');
+
+        def ok => (is([{'a' => 1}], [{'a' => 1}], "complex pass", 'diag'), 'complex pass');
+        def ok => (!is([{'a' => 2, 'b' => 3}], [{'a' => 1}], "complex fail", 'diag'), 'complex fail');
+
+        def ok => (is(undef, undef), 'undef pass');
+        def ok => (!is(0, undef), 'undef fail');
+
+        my $true  = do { bless \(my $dummy = 1), "My::Boolean" };
+        my $false = do { bless \(my $dummy = 0), "My::Boolean" };
+        def ok => (is($true,  $true,  "true scalar ref is itself"),  "true scalar ref is itself");
+        def ok => (is($false, $false, "false scalar ref is itself"), "false scalar ref is itself");
+
+        my $x = \\"123";
+        def ok => (is($x, \\"123", "Ref-Ref check 1"), "Ref-Ref check 1");
+
+        $x = \[123];
+        def ok => (is($x, \["123"], "Ref-Ref check 2"), "Ref-Ref check 2");
+
+        def ok => (!is(\$x, \\["124"], "Ref-Ref check 3"), "Ref-Ref check 3");
+    };
+
+    do_def;
+
+    like(
+        $events,
+        array {
+            event Ok => sub {
+                call pass => T();
+                call name => undef;
+            };
+
+            event Ok => sub {
+                call pass => T();
+                call name => 'simple pass';
+            };
+
+            fail_events Ok => sub {
+                call pass => F();
+                call name => 'simple fail';
+            };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK/],
+                    rows   => [[qw/a eq b/]],
+                );
+            };
+            event Diag => { message => 'diag' };
+
+            event Ok => sub {
+                call pass => T();
+                call name => 'complex pass';
+            };
+
+            fail_events Ok => sub {
+                call pass => F();
+                call name => 'complex fail';
+            };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/PATH GOT OP CHECK/],
+                    rows   => [
+                        [qw/[0]{a} 2 eq 1/],
+                        [qw/[0]{b} 3 !exists/, '<DOES NOT EXIST>'],
+                    ],
+                );
+            };
+            event Diag => { message => 'diag' };
+
+            event Ok => sub {
+                call pass => T();
+            };
+
+            fail_events Ok => sub {
+                call pass => F();
+            };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK/],
+                    rows   => [[qw/0 IS <UNDEF>/]],
+                );
+            };
+
+            event Ok => sub {
+                call pass => T();
+                call name => "true scalar ref is itself";
+            };
+
+            event Ok => sub {
+                call pass => T();
+                call name => "false scalar ref is itself";
+            };
+
+            event Ok => sub {
+                call pass => T();
+                call name => "Ref-Ref check 1";
+            };
+
+            event Ok => sub {
+                call pass => T();
+                call name => "Ref-Ref check 2";
+            };
+
+            fail_events Ok => sub {
+                call pass => F();
+                call name => 'Ref-Ref check 3';
+            };
+
+            event Diag => { message => match qr/\$\*->\$\*->\[0\] \| 123 \| eq \| 124/ };
+
+            end;
+        },
+        "Got expected events"
+    );
+};
+
+subtest like => sub {
+    my $events = intercept {
+        def ok => (like(1, 1), '2 arg pass');
+
+        def ok => (like('a', qr/a/, "simple pass", 'diag'), 'simple pass');
+        def ok => (!like('b', qr/a/, "simple fail", 'diag'), 'simple fail');
+
+        def ok => (like([{'a' => 1, 'b' => 2}, 'a'], [{'a' => 1}], "complex pass", 'diag'), 'complex pass');
+        def ok => (!like([{'a' => 2, 'b' => 2}, 'a'], [{'a' => 1}], "complex fail", 'diag'), 'complex fail');
+
+        my $str = bless {}, 'My::String';
+        def ok => (like($str, qr/xxx/, 'overload pass'), "overload pass");
+        def ok => (!like($str, qr/yyy/, 'overload fail'), "overload fail");
+
+    };
+
+    do_def;
+
+    my $rx = "" . qr/a/;
+
+    like(
+        $events,
+        array {
+            event Ok => sub {
+                call pass => T();
+                call name => undef;
+            };
+
+            event Ok => sub {
+                call pass => T();
+                call name => 'simple pass';
+            };
+
+            fail_events Ok => sub {
+                call pass => F();
+                call name => 'simple fail';
+            };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK/],
+                    rows   => [[qw/b =~/, "$rx"]],
+                );
+            };
+            event Diag => { message => 'diag' };
+
+            event Ok => sub {
+                call pass => T();
+                call name => 'complex pass';
+            };
+
+            fail_events Ok => sub {
+                call pass => F();
+                call name => 'complex fail';
+            };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/PATH GOT OP CHECK/],
+                    rows   => [[qw/[0]{a} 2 eq 1/]],
+                );
+            };
+            event Diag => { message => 'diag' };
+
+            event Ok => sub {
+                call pass => T();
+                call name => 'overload pass';
+            };
+
+            $rx = qr/yyy/;
+            fail_events Ok => sub {
+                call pass => F();
+                call name => 'overload fail';
+            };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK/],
+                    rows   => [[qw/xxx =~/, "$rx"]],
+                );
+            };
+
+            end;
+        },
+        "Got expected events"
+    );
+};
+
+subtest shortcuts => sub {
+    is(1,            T(), "true");
+    is('a',          T(), "true");
+    is(' ',          T(), "true");
+    is('0 but true', T(), "true");
+
+    my @lines;
+    my $events = intercept {
+        is(0, T(), "not true");     push @lines => __LINE__;
+        is('', T(), "not true");    push @lines => __LINE__;
+        is(undef, T(), "not true"); push @lines => __LINE__;
+    };
+    like(
+        $events,
+        array {
+            filter_items { grep { !$_->isa('Test2::Event::Diag') } @_ };
+            event Ok => sub { call pass => 0; prop line => $lines[0]; prop file => __FILE__; };
+            event Ok => sub { call pass => 0; prop line => $lines[1]; prop file => __FILE__; };
+            event Ok => sub { call pass => 0; prop line => $lines[2]; prop file => __FILE__; };
+            end()
+        },
+        "T() fails for untrue",
+    );
+
+    is(0,     F(), "false");
+    is('',    F(), "false");
+    is(undef, F(), "false");
+
+    $events = intercept {
+        is(1,   F(), "not false");
+        is('a', F(), "not false");
+        is(' ', F(), "not false");
+    };
+    like(
+        $events,
+        array {
+            filter_items { grep { !$_->isa('Test2::Event::Diag') } @_ };
+            event Ok => {pass => 0};
+            event Ok => {pass => 0};
+            event Ok => {pass => 0};
+            end()
+        },
+        "F() fails for true",
+    );
+
+    is(undef, U(), "not defined");
+
+    like(
+        intercept { is(0, U(), "not defined") },
+        array { event Ok => { pass => 0 } },
+        "0 is defined"
+    );
+
+    is(0,            D(), "defined");
+    is(1,            D(), "defined");
+    is('',           D(), "defined");
+    is(' ',          D(), "defined");
+    is('0 but true', D(), "defined");
+
+    like(
+        intercept { is(undef, D(), "not defined") },
+        array { event Ok => { pass => 0 } },
+        "undef is not defined"
+    );
+
+    is(0,            DF(), "defined but false");
+    is('',           DF(), "defined but false");
+
+    like(
+        intercept {
+          is(undef,        DF());
+          is(1,            DF());
+          is(' ',          DF());
+          is('0 but true', DF());
+        },
+        array {
+          filter_items { grep { !$_->isa('Test2::Event::Diag') } @_ };
+          event Ok => { pass => 0 };
+          event Ok => { pass => 0 };
+          event Ok => { pass => 0 };
+          event Ok => { pass => 0 };
+        },
+        "got fail for DF"
+    );
+
+    is([undef], [E()],   "does exist");
+    is([],      [DNE()], "does not exist");
+    is({}, {a => DNE()}, "does not exist");
+    $events = intercept {
+        is([], [E()]);
+        is([undef], [DNE()]);
+        is({a => undef}, {a => DNE()});
+    };
+    like(
+        $events,
+        array {
+            filter_items { grep { !$_->isa('Test2::Event::Diag') } @_ };
+            event Ok => { pass => 0 };
+            event Ok => { pass => 0 };
+            event Ok => { pass => 0 };
+        },
+        "got failed event"
+    );
+
+    is([], [FDNE()], "does not exist");
+    is({}, {a => FDNE()}, "does not exist");
+    is([undef], [FDNE()], "false");
+    is({a => undef}, {a => FDNE()}, "false");
+
+    $events = intercept {
+        is([1], [FDNE()]);
+        is({a => 1}, {a => FDNE()});
+    };
+    like(
+        $events,
+        array {
+            filter_items { grep { !$_->isa('Test2::Event::Diag') } @_ };
+            event Ok => { pass => 0 };
+            event Ok => { pass => 0 };
+        },
+        "got failed event"
+    );
+};
+
+subtest exact_ref => sub {
+    my $ref = {};
+
+    my $check = exact_ref($ref); my $line  = __LINE__;
+    is($check->lines, [$line], "correct line");
+
+    my $hash = {};
+    my $events = intercept {
+        is($ref,  $check, "pass");
+        is($hash, $check, "fail");
+    };
+
+    like(
+        $events,
+        array {
+            event Ok => {pass => 1};
+            fail_events Ok => {pass => 0};
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [["$hash", '==', "$ref", $line]],
+                );
+            };
+
+            end;
+        },
+        "Got events"
+    );
+};
+
+subtest string => sub {
+    my $check = string "foo"; my $line = __LINE__;
+    is($check->lines, [$line], "Got line number");
+
+    my $events = intercept {
+        is('foo', $check, "pass");
+        is('bar', $check, "fail");
+    };
+
+    like(
+        $events,
+        array {
+            event Ok => {pass => 1};
+            fail_events Ok => { pass => 0 };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [[qw/bar eq foo/, $line]],
+                );
+            };
+            end;
+        },
+        "Got events"
+    );
+
+    my ($check1, $check2) = (string("foo", negate => 1), !string("foo"));
+    $line = __LINE__ - 1;
+
+    for $check ($check1, $check2) {
+        is($check->lines, [$line], "Got line number");
+
+        $events = intercept {
+            is('bar', $check1, "pass");
+            is('foo', $check1, "fail");
+        };
+
+        like(
+            $events,
+            array {
+                event Ok => {pass => 1};
+                fail_events Ok => {pass => 0};
+                event Diag => sub {
+                    call message => table(
+                        header => [qw/GOT OP CHECK LNs/],
+                        rows   => [[qw/foo ne foo/, $line]],
+                    );
+                };
+                end;
+            },
+            "Got events"
+        );
+    }
+};
+
+subtest number => sub {
+    my $check = number "22.0"; my $line = __LINE__;
+    is($check->lines, [$line], "Got line number");
+
+    my $events = intercept {
+        is(22, $check, "pass");
+        is("22.0", $check, "pass");
+        is(12, $check, "fail");
+        is('xxx', $check, "fail");
+    };
+
+    like(
+        $events,
+        array {
+            event Ok => {pass => 1};
+            event Ok => {pass => 1};
+            fail_events Ok => {pass => 0};
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [[qw/12 == 22.0/, $line]],
+                );
+            };
+
+            fail_events Ok => { pass => 0 };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [[qw/xxx == 22.0/, $line]],
+                );
+            };
+            end;
+        },
+        "Got events"
+    );
+
+    my ($check1, $check2) = (number("22.0", negate => 1), !number("22.0"));
+    $line = __LINE__ - 1;
+
+    for $check ($check1, $check2) {
+        is($check->lines, [$line], "Got line number");
+
+        $events = intercept {
+            is(12, $check, "pass");
+            is(22, $check, "fail");
+            is("22.0", $check, "fail");
+            is('xxx', $check, "fail");
+        };
+
+        like(
+            $events,
+            array {
+                event Ok => {pass => 1};
+                fail_events Ok => { pass => 0 };
+                event Diag => sub {
+                    call message => table(
+                        header => [qw/GOT OP CHECK LNs/],
+                        rows   => [[qw/22 != 22.0/, $line]],
+                    );
+                };
+
+                fail_events Ok => { pass => 0 };
+                event Diag => sub {
+                    call message => table(
+                        header => [qw/GOT OP CHECK LNs/],
+                        rows   => [[qw/22.0 != 22.0/, $line]],
+                    );
+                };
+
+                fail_events Ok => { pass => 0 };
+                event Diag => sub {
+                    call message => table(
+                        header => [qw/GOT OP CHECK LNs/],
+                        rows   => [[qw/xxx != 22.0/, $line]],
+                    );
+                };
+
+                end;
+            },
+            "Got events"
+        );
+    }
+};
+
+subtest bool => sub {
+    my @true = (1, 'yup', '0 but true', ' ', {});
+    my @false = (0, '0', '', undef);
+
+    for my $true (@true) {
+        for my $true2 (@true) {
+            is($true2, bool($true), "Both true");
+
+            my $line = __LINE__ + 2;
+            is(
+                intercept { is($true2, !bool($true)) },
+                array {
+                    fail_events Ok => {pass => 0};
+                    event Diag => sub {
+                        call message => table(
+                            header => [qw/GOT OP CHECK LNs/],
+                            rows   => [["<TRUE ($true2)>", '!=', "<TRUE ($true)>", $line]],
+                        );
+                    };
+                    end;
+                },
+                "true($true2) + true($true) + negate"
+            );
+        }
+
+        for my $false (@false) {
+            is($false, !bool($true), "true + false + !");
+            is($false, bool($true, negate => 1), "true + false + negate");
+
+            my $render = '<FALSE (' . (defined($false) ? length($false) ? $false : "''" : 'undef') . ')>';
+
+            my $line = __LINE__ + 2;
+            is(
+                intercept { is($false, bool($true)) },
+                array {
+                    fail_events Ok => {pass => 0};
+                    event Diag => sub {
+                        call message => table(
+                            header => [qw/GOT OP CHECK LNs/],
+                            rows   => [[$render, '==', "<TRUE ($true)>", $line]],
+                        );
+                    };
+                    end;
+                },
+                "$render + TRUE ($true) + negate"
+            );
+        }
+    }
+
+    for my $false (@false) {
+        my $render1 = '<FALSE (' . (defined($false) ? length($false) ? $false : "''" : 'undef') . ')>';
+        for my $false2 (@false) {
+            is($false2, bool($false), "false + false");
+
+            my $render2 = '<FALSE (' . (defined($false2) ? length($false2) ? $false2 : "''" : 'undef') . ')>';
+
+            my $line = __LINE__ + 2;
+            is(
+                intercept { is($false2, !bool($false)) },
+                array {
+                    fail_events Ok => {pass => 0};
+                    event Diag => sub {
+                        call message => table(
+                            header => [qw/GOT OP CHECK LNs/],
+                            rows   => [[$render2, '!=', $render1, $line]],
+                        );
+                    };
+                    end;
+                },
+                "$render2 + $render1 + negate"
+            );
+        }
+
+        for my $true (@true) {
+            is($true, !bool($false), "true + false + !");
+            is($true, bool($false, negate => 1), "true + false + negate");
+
+            my $line = __LINE__ + 2;
+            is(
+                intercept { is($true, bool($false)) },
+                array {
+                    fail_events Ok => {pass => 0};
+                    event Diag => sub {
+                        call message => table(
+                            header => [qw/GOT OP CHECK LNs/],
+                            rows   => [["<TRUE ($true)>", '==', $render1, $line]],
+                        );
+                    };
+                    end;
+                },
+                "TRUE ($true) + $render1 + negate"
+            );
+        }
+    }
+
+    my $arr  = [];
+    my $line = __LINE__ + 2;
+    is(
+        intercept { is($arr, [bool(0)]) },
+        array {
+            fail_events Ok => {pass => 0};
+            event Diag => sub {
+                call message => table(
+                    header => [qw/PATH GOT OP CHECK LNs/],
+                    rows   => [['[0]', "<DOES NOT EXIST>", '==', '<FALSE (0)>', $line],],
+                );
+            };
+            end;
+        },
+        "Value must exist"
+    );
+};
+
+
+subtest match => sub {
+    my $check = match qr/xyz/; my $line = __LINE__;
+    is($check->lines, [$line], "Got line number");
+
+    my $events = intercept {
+        is('axyzb', $check, "pass");
+        is('abcde', $check, "fail");
+    };
+
+    my $rx = "" . qr/xyz/;
+    like(
+        $events,
+        array {
+            event Ok => {pass => 1};
+            fail_events Ok => {pass => 0};
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [[qw/abcde =~/, "$rx", $line]],
+                );
+            };
+            end;
+        },
+        "Got events"
+    );
+};
+
+subtest '!match' => sub {
+    my $check = !match qr/xyz/; my $line = __LINE__;
+    is($check->lines, [$line], "Got line number");
+
+    my $events = intercept {
+        is('abcde', $check, "pass");
+        is('axyzb', $check, "fail");
+    };
+
+    my $rx = "" . qr/xyz/;
+    like(
+        $events,
+        array {
+            event Ok => {pass => 1};
+            fail_events Ok => {pass => 0};
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [[qw/axyzb !~/, "$rx", $line]],
+                );
+            };
+            end;
+        },
+        "Got events"
+    );
+};
+
+subtest '!mismatch' => sub {
+    my $check = !mismatch qr/xyz/; my $line = __LINE__;
+    is($check->lines, [$line], "Got line number");
+
+    my $events = intercept {
+        is('axyzb', $check, "pass");
+        is('abcde', $check, "fail");
+    };
+
+    my $rx = "" . qr/xyz/;
+    like(
+        $events,
+        array {
+            event Ok => {pass => 1};
+            fail_events Ok => {pass => 0};
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [[qw/abcde =~/, "$rx", $line]],
+                );
+            };
+            end;
+        },
+        "Got events"
+    );
+};
+
+subtest mismatch => sub {
+    my $check = mismatch qr/xyz/; my $line = __LINE__;
+    is($check->lines, [$line], "Got line number");
+
+    my $events = intercept {
+        is('abcde', $check, "pass");
+        is('axyzb', $check, "fail");
+    };
+
+    my $rx = "" . qr/xyz/;
+    like(
+        $events,
+        array {
+            event Ok => {pass => 1};
+            fail_events Ok => {pass => 0};
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [[qw/axyzb !~/, "$rx", $line]],
+                );
+            };
+            end;
+        },
+        "Got events"
+    );
+};
+
+subtest check => sub {
+    my @lines;
+    my $one = validator sub { $_ ? 1 : 0 }; push @lines => __LINE__;
+    my $two = validator two => sub { $_ ? 1 : 0 }; push @lines => __LINE__;
+    my $thr = validator 't', thr => sub { $_ ? 1 : 0 }; push @lines => __LINE__;
+
+    is($one->lines, [$lines[0]], "line 1");
+    is($two->lines, [$lines[1]], "line 2");
+    is($thr->lines, [$lines[2]], "line 3");
+
+    my $events = intercept {
+        is(1, $one, 'pass');
+        is(1, $two, 'pass');
+        is(1, $thr, 'pass');
+
+        is(0, $one, 'fail');
+        is(0, $two, 'fail');
+        is(0, $thr, 'fail');
+    };
+
+    like(
+        $events,
+        array {
+            event Ok => {pass => 1};
+            event Ok => {pass => 1};
+            event Ok => {pass => 1};
+
+            fail_events Ok => {pass => 0};
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [[0, 'CODE(...)', '<Custom Code>', $lines[0]]],
+                );
+            };
+
+            fail_events Ok => {pass => 0};
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [[0, 'CODE(...)', 'two', $lines[1]]],
+                );
+            };
+
+            fail_events Ok => {pass => 0};
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK LNs/],
+                    rows   => [[0, 't', 'thr', $lines[2]]],
+                );
+            };
+            end;
+        },
+        "Got events"
+    );
+};
+
+subtest prop => sub {
+    like(
+        dies { prop x => 1 },
+        qr/No current build/,
+        "Need a build"
+    );
+
+    like(
+        dies { [meta { my $x = prop x => 1 }] },
+        qr/'prop' should only ever be called in void context/,
+        "restricted context"
+    );
+
+    like(
+        dies { [array { prop x => 1 }] },
+        qr/'Test2::Compare::Array.*' does not support meta-checks/,
+        "not everything supports properties"
+    );
+};
+
+subtest end => sub {
+    like(
+        dies { end() },
+        qr/No current build/,
+        "Need a build"
+    );
+
+    like(
+        dies { [meta { end() }] },
+        qr/'Test2::Compare::Meta.*' does not support 'ending'/,
+        "Build does not support end"
+    );
+
+    like(
+        dies { [array { [end()] }] },
+        qr/'end' should only ever be called in void context/,
+        "end context"
+    );
+};
+
+subtest field => sub {
+    like(
+        dies { field a => 1 },
+        qr/No current build/,
+        "Need a build"
+    );
+
+    like(
+        dies { [array { field a => 1 }] },
+        qr/'Test2::Compare::Array.*' does not support hash field checks/,
+        "Build does not take fields"
+    );
+
+    like(
+        dies { [hash { [field a => 1] }] },
+        qr/'field' should only ever be called in void context/,
+        "field context"
+    );
+};
+
+subtest filter_items => sub {
+    like(
+        dies { filter_items {1} },
+        qr/No current build/,
+        "Need a build"
+    );
+
+    like(
+        dies { [hash { filter_items {1} }] },
+        qr/'Test2::Compare::Hash.*' does not support filters/,
+        "Build does not take filters"
+    );
+
+    like(
+        dies { [array { [filter_items {1}] }] },
+        qr/'filter_items' should only ever be called in void context/,
+        "filter context"
+    );
+};
+
+subtest item => sub {
+    like(
+        dies { item 0 => 'a' },
+        qr/No current build/,
+        "Need a build"
+    );
+
+    like(
+        dies { [hash { item 0 => 'a' }] },
+        qr/'Test2::Compare::Hash.*' does not support array item checks/,
+        "Build does not take items"
+    );
+
+    like(
+        dies { [array { [ item 0 => 'a' ] }] },
+        qr/'item' should only ever be called in void context/,
+        "item context"
+    );
+};
+
+subtest call => sub {
+    like(
+        dies { call foo => 1 },
+        qr/No current build/,
+        "Need a build"
+    );
+
+    like(
+        dies { [hash { call foo => 1 }] },
+        qr/'Test2::Compare::Hash.*' does not support method calls/,
+        "Build does not take methods"
+    );
+
+    like(
+        dies { [object { [ call foo => 1 ] }] },
+        qr/'call' should only ever be called in void context/,
+        "call context"
+    );
+};
+
+subtest check => sub {
+    like(
+        dies { check 'a' },
+        qr/No current build/,
+        "Need a build"
+    );
+
+    like(
+        dies { [hash { check 'a' }] },
+        qr/'Test2::Compare::Hash.*' is not a check-set/,
+        "Build must support checks"
+    );
+
+    like(
+        dies { [in_set(sub { [ check 'a' ] })] },
+        qr/'check' should only ever be called in void context/,
+        "check context"
+    );
+};
+
+subtest meta => sub {
+    my $x = bless {}, 'Foo';
+    my $check = meta {
+        prop blessed => 'Foo';
+        prop reftype => 'HASH';
+        prop this    => $x;
+    };
+    my @lines = map { __LINE__ - $_ } reverse 1 .. 5;
+
+    is($x, $check, "meta pass");
+
+    my $array = [];
+    my $events = intercept { is($array, $check, "meta fail") };
+    like(
+        $events,
+        array {
+            fail_events Ok => sub { call pass => 0 };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/PATH GOT OP CHECK LNs/],
+                    rows   => [
+                        ["", $array, '', '<META CHECKS>', "$lines[0], $lines[4]"],
+                        ['<blessed>', '<UNDEF>', '',   'Foo',  $lines[1]],
+                        ['<reftype>', 'ARRAY',   'eq', 'HASH', $lines[2]],
+                        ['<this>', $array, '', '<HASH>', $lines[3]],
+                    ],
+                );
+            };
+        },
+        "got failure"
+    );
+};
+
+subtest hash => sub {
+    my $empty = hash { etc };
+
+    my $full = hash {
+        field a => 1;
+        field b => 2;
+        etc;
+    };
+
+    my $closed = hash {
+        field a => 1;
+        field b => 2;
+        end();
+    };
+
+    isa_ok($_, 'Test2::Compare::Base', 'Test2::Compare::Hash') for $empty, $full, $closed;
+
+    is({}, $empty, "empty hash");
+    is({a => 1}, $empty, "unclosed empty matches anything");
+
+    is({a => 1, b => 2}, $full, "full exact match");
+    is({a => 1, b => 2, c => 3 }, $full, "full with extra");
+
+    is({a => 1, b => 2}, $closed, "closed");
+
+    my $events = intercept {
+        is([], $empty);
+        is(undef, $empty);
+        is(1, $empty);
+        is('HASH', $empty);
+
+        is({}, $full);
+        is({a => 2, b => 2}, $full);
+
+        is({a => 1, b => 2, c => 3}, $closed);
+    };
+
+    @$events = grep {$_->isa('Test2::Event::Ok')} @$events;
+
+    is(@$events, 7, '7 events');
+    is($_->pass, 0, "event failed") for @$events;
+};
+
+subtest array => sub {
+    my $empty = array { etc };
+
+    my $simple = array {
+        item 'a';
+        item 'b';
+        item 'c';
+        etc;
+    };
+
+    my $filtered = array {
+        filter_items { grep { m/a/ } @_ };
+        item 0 => 'a';
+        item 1 => 'a';
+        item 2 => 'a';
+        etc;
+    };
+
+    my $shotgun = array {
+        item 1 => 'b';
+        item 3 => 'd';
+        etc;
+    };
+
+    my $closed = array {
+        item 0 => 'a';
+        item 1 => 'b';
+        item 2 => 'c';
+        end;
+    };
+
+    is([], $empty, "empty array");
+    is(['a'], $empty, "any array matches empty");
+
+    is([qw/a b c/], $simple, "simple exact match");
+    is([qw/a b c d e/], $simple, "simple with extra");
+
+    is([qw/x a b c a v a t t/], $filtered, "filtered out unwanted values");
+
+    is([qw/a b c d e/], $shotgun, "selected indexes only");
+
+    is([qw/a b c/], $closed, "closed array");
+
+    my $events = intercept {
+        is({}, $empty);
+        is(undef, $empty);
+        is(1, $empty);
+        is('ARRAY', $empty);
+
+        is([qw/x y z/], $simple);
+        is([qw/a b x/], $simple);
+        is([qw/x b c/], $simple);
+
+        is([qw/aa a a a b/], $filtered);
+
+        is([qw/b c d e f/], $shotgun);
+
+        is([qw/a b c d/], $closed);
+    };
+
+    @$events = grep {$_->isa('Test2::Event::Ok')} @$events;
+    is(@$events, 10, "10 events");
+    is($_->pass, 0, "event failed") for @$events;
+};
+
+subtest bag => sub {
+    my $empty = bag { etc };
+
+    my $simple = bag {
+        item 'a';
+        item 'b';
+        item 'c';
+        etc;
+    };
+
+    my $closed = array {
+        item 0 => 'a';
+        item 1 => 'b';
+        item 2 => 'c';
+        end;
+    };
+
+    is([], $empty, "empty array");
+    is(['a'], $empty, "any array matches empty");
+
+    is([qw/a b c/], $simple, "simple exact match");
+    is([qw/b c a/], $simple, "simple out of order");
+    is([qw/a b c d e/], $simple, "simple with extra");
+    is([qw/b a d e c/], $simple, "simple with extra, out of order");
+
+    is([qw/a b c/], $closed, "closed array");
+
+    my $events = intercept {
+        is({}, $empty);
+        is(undef, $empty);
+        is(1, $empty);
+        is('ARRAY', $empty);
+
+        is([qw/x y z/], $simple);
+        is([qw/a b x/], $simple);
+        is([qw/x b c/], $simple);
+
+        is([qw/a b c d/], $closed);
+    };
+
+    @$events = grep {$_->isa('Test2::Event::Ok')} @$events;
+    is(@$events, 8, "8 events");
+    is($_->pass, 0, "event failed") for @$events;
+};
+
+subtest object => sub {
+    my $empty = object { };
+
+    my $simple = object {
+        call foo => 'foo';
+        call bar => 'bar';
+        call_list many => [1,2,3,4];
+        call_hash many => {1=>2,3=>4};
+        call [args => qw(a b)] => {a=>'b'};
+    };
+
+    my $array = object {
+        call foo => 'foo';
+        call bar => 'bar';
+        call_list many => [1,2,3,4];
+        call_hash many => {1=>2,3=>4};
+        call [args => qw(a b)] => {a=>'b'};
+        item 0 => 'x';
+        item 1 => 'y';
+        etc;
+    };
+
+    my $closed_array = object {
+        call foo => 'foo';
+        call bar => 'bar';
+        call_list many => [1,2,3,4];
+        call_hash many => {1=>2,3=>4};
+        call [args => qw(a b)] => {a=>'b'};
+        item 0 => 'x';
+        item 1 => 'y';
+        end();
+    };
+
+    my $hash = object {
+        call foo => 'foo';
+        call bar => 'bar';
+        call_list many => [1,2,3,4];
+        call_hash many => {1=>2,3=>4};
+        call [args => qw(a b)] => {a=>'b'};
+        field x => 1;
+        field y => 2;
+        etc;
+    };
+
+    my $closed_hash = object {
+        call foo => 'foo';
+        call bar => 'bar';
+        call_list many => [1,2,3,4];
+        call_hash many => {1=>2,3=>4};
+        call [args => qw(a b)] => {a=>'b'};
+        field x => 1;
+        field y => 2;
+        end();
+    };
+
+    my $meta = object {
+        call foo => 'foo';
+        call bar => 'bar';
+        call_list many => [1,2,3,4];
+        call_hash many => {1=>2,3=>4};
+        call [args => qw(a b)] => {a=>'b'};
+        prop blessed => 'ObjectFoo';
+        prop reftype => 'HASH';
+        etc;
+    };
+
+    my $mix = object {
+        call foo => 'foo';
+        call bar => 'bar';
+        call_list many => [1,2,3,4];
+        call_hash many => {1=>2,3=>4};
+        call [args => qw(a b)] => {a=>'b'};
+        field x => 1;
+        field y => 2;
+        prop blessed => 'ObjectFoo';
+        prop reftype => 'HASH';
+        etc;
+    };
+
+    my $obf = mock 'ObjectFoo' => (add => [
+        foo => sub { 'foo' },
+        bar => sub { 'bar' },
+        baz => sub {'baz'},
+        many => sub { (1,2,3,4) },
+        args => sub { shift; +{@_} },
+    ]);
+    my $obb = mock 'ObjectBar' => (add => [
+        foo => sub { 'nop' },
+        baz => sub { 'baz' },
+        many => sub { (1,2,3,4) },
+        args => sub { shift; +{@_} },
+    ]);
+
+    is(bless({}, 'ObjectFoo'), $empty, "Empty matches any object");
+    is(bless({}, 'ObjectBar'), $empty, "Empty matches any object");
+
+    is(bless({}, 'ObjectFoo'), $simple, "simple match hash");
+    is(bless([], 'ObjectFoo'), $simple, "simple match array");
+
+    is(bless([qw/x y/], 'ObjectFoo'), $array, "array match");
+    is(bless([qw/x y z/], 'ObjectFoo'), $array, "array match");
+
+    is(bless([qw/x y/], 'ObjectFoo'), $closed_array, "closed array");
+
+    is(bless({x => 1, y => 2}, 'ObjectFoo'), $hash, "hash match");
+    is(bless({x => 1, y => 2, z => 3}, 'ObjectFoo'), $hash, "hash match");
+
+    is(bless({x => 1, y => 2}, 'ObjectFoo'), $closed_hash, "closed hash");
+
+    is(bless({}, 'ObjectFoo'), $meta, "meta match");
+
+    is(bless({x => 1, y => 2, z => 3}, 'ObjectFoo'), $mix, "mix");
+
+    my $events = intercept {
+        is({}, $empty);
+        is(undef, $empty);
+        is(1, $empty);
+        is('ARRAY', $empty);
+
+        is(bless({}, 'ObjectBar'), $simple, "simple match hash");
+        is(bless([], 'ObjectBar'), $simple, "simple match array");
+
+        is(bless([qw/a y/], 'ObjectFoo'), $array, "array match");
+        is(bless([qw/a y z/], 'ObjectFoo'), $array, "array match");
+
+        is(bless([qw/x y z/], 'ObjectFoo'), $closed_array, "closed array");
+
+        is(bless({x => 2, y => 2}, 'ObjectFoo'), $hash, "hash match");
+        is(bless({x => 2, y => 2, z => 3}, 'ObjectFoo'), $hash, "hash match");
+
+        is(bless({x => 1, y => 2, z => 3}, 'ObjectFoo'), $closed_hash, "closed hash");
+
+        is(bless({}, 'ObjectBar'), $meta, "meta match");
+        is(bless([], 'ObjectFoo'), $meta, "meta match");
+
+        is(bless({}, 'ObjectFoo'), $mix, "mix");
+        is(bless([], 'ObjectFoo'), $mix, "mix");
+        is(bless({x => 1, y => 2, z => 3}, 'ObjectBar'), $mix, "mix");
+    };
+
+    @$events = grep {$_->isa('Test2::Event::Ok')} @$events;
+    is(@$events, 17, "17 events");
+    is($_->pass, 0, "event failed") for @$events;
+
+};
+
+subtest event => sub {
+    like(
+        dies { event 0 => {} },
+        qr/type is required/,
+        "Must specify event type"
+    );
+
+    my $one = event Ok => {};
+    is($one->meta->items->[0]->[1], 'Test2::Event::Ok', "Event type check");
+
+    $one = event '+Foo::Event::Diag' => {};
+    is($one->meta->items->[0]->[1], 'Foo::Event::Diag', "Event type check with +");
+
+    my $empty = event 'Ok';
+    isa_ok($empty, 'Test2::Compare::Event');
+
+    like(
+        dies { event Ok => 'xxx' },
+        qr/'xxx' is not a valid event specification/,
+        "Invalid spec"
+    );
+
+    my $from_sub = event Ok => sub {
+        call pass  => 1;
+        field name => 'pass';
+        etc;
+    };
+
+    my $from_hash = event Ok => sub { field pass => 1; field name => 'pass'; etc};
+
+    my $from_build = array { event Ok => sub { field pass => 1; field name => 'pass'; etc } };
+
+    my $pass = intercept { ok(1, 'pass') };
+    my $fail = intercept { ok(0, 'fail') };
+    my $diag = intercept { diag("hi") };
+
+    is($pass->[0], $empty,      "empty matches any event of the type");
+    is($fail->[0], $empty,      "empty on a failed event");
+    is($pass->[0], $from_sub,   "builder worked");
+    is($pass->[0], $from_hash,  "hash spec worked");
+    is($pass,      $from_build, "worked in build");
+
+    my $events = intercept {
+        is($diag->[0], $empty);
+
+        is($fail->[0], $from_sub,   "builder worked");
+        is($fail->[0], $from_hash,  "hash spec worked");
+        is($fail,      $from_build, "worked in build");
+    };
+
+    @$events = grep {$_->isa('Test2::Event::Ok')} @$events;
+    is(@$events, 4, "4 events");
+    is($_->pass, 0, "event failed") for @$events;
+
+    like(
+        dies { event Ok => {}; 1 },
+        qr/No current build!/,
+        "Need a build!"
+    );
+};
+
+subtest sets => sub {
+    subtest check_set => sub {
+        is(
+            'foo',
+            check_set(sub { check 'foo'; check match qr/fo/; check match qr/oo/ }),
+            "matches everything in set"
+        );
+
+        is(
+            'foo',
+            check_set('foo', match qr/fo/, match qr/oo/),
+            "matches everything in set"
+        );
+
+        like(
+            intercept {
+                is('fox', check_set(sub{ check match qr/fo/; check 'foo' }));
+                is('fox', check_set(match qr/fo/, 'foo'));
+            },
+            array {
+                filter_items { grep { !$_->isa('Test2::Event::Diag') } @_ };
+                event Ok => { pass => 0 };
+                event Ok => { pass => 0 };
+                end;
+            },
+            "Failed cause not all checks passed"
+        );
+    };
+
+    subtest in_set => sub {
+        is(
+            'foo',
+            in_set(sub { check 'x'; check 'y'; check 'foo' }),
+            "Item is in set"
+        );
+        is(
+            'foo',
+            in_set(qw/x y foo/),
+            "Item is in set"
+        );
+
+        like(
+            intercept {
+                is('fox', in_set(sub{ check 'x'; check 'foo' }));
+                is('fox', in_set('x', 'foo'));
+            },
+            array {
+                filter_items { grep { !$_->isa('Test2::Event::Diag') } @_ };
+                event Ok => { pass => 0 };
+                event Ok => { pass => 0 };
+                end;
+            },
+            "Failed cause not all checks passed"
+        );
+    };
+
+    subtest not_in_set => sub {
+        is(
+            'foo',
+            not_in_set(sub { check 'x'; check 'y'; check 'z' }),
+            "Item is not in set"
+        );
+        is(
+            'foo',
+            not_in_set(qw/x y z/),
+            "Item is not in set"
+        );
+
+        like(
+            intercept {
+                is('fox', not_in_set(sub{ check 'x'; check 'fox' }));
+                is('fox', not_in_set('x', 'fox'));
+            },
+            array {
+                filter_items { grep { !$_->isa('Test2::Event::Diag') } @_ };
+                event Ok => { pass => 0 };
+                event Ok => { pass => 0 };
+                end;
+            },
+            "Failed cause not all checks passed"
+        );
+
+    };
+};
+
+subtest regex => sub {
+    is(qr/abc/, qr/abc/, "same regex");
+
+    my $events = intercept {
+        is(qr/abc/i, qr/abc/, "Wrong flags");
+        is(qr/abc/, qr/abcd/, "wrong pattern");
+        is(qr/abc/, exact_ref(qr/abc/), "not an exact match");
+    };
+
+    @$events = grep {$_->isa('Test2::Event::Ok')} @$events;
+    is(@$events, 3, "3 events");
+    ok(!$_->{pass}, "Event was a failure") for @$events
+};
+
+subtest isnt => sub {
+    isnt('a', 'b', "a is not b");
+    isnt({}, [], "has is not array");
+    isnt(0, 1, "0 is not 1");
+
+    my $events = intercept {
+        isnt([], []);
+        isnt('a', 'a');
+        isnt(1, 1);
+        isnt({}, {});
+    };
+
+    @$events = grep {$_->isa('Test2::Event::Ok')} @$events;
+    is(@$events, 4, "4 events");
+    ok(!$_->{pass}, "Event was a failure") for @$events
+};
+
+subtest unlike => sub {
+    unlike('a', 'b', "a is not b");
+    unlike({}, [], "has is not array");
+    unlike(0, 1, "0 is not 1");
+    unlike('aaa', qr/bbb/, "aaa does not match /bbb/");
+
+    my $events = intercept {
+        unlike([], []);
+        unlike('a', 'a');
+        unlike(1, 1);
+        unlike({}, {});
+        unlike( 'foo', qr/o/ );
+    };
+
+    @$events = grep {$_->isa('Test2::Event::Ok')} @$events;
+    is(@$events, 5, "5 events");
+    ok(!$_->{pass}, "Event was a failure") for @$events
+};
+
+subtest all_items => sub {
+    like(
+        [qw/a aa aaa/],
+        array {
+            all_items match qr/^a+$/;
+            item 'a';
+            item 'aa';
+        },
+        "All items match regex"
+    );
+
+    my @lines;
+    my $array = [qw/a aa aaa/];
+    my $regx = qr/^b+$/;
+    my $events = intercept {
+        is(
+            $array,
+            array {
+                all_items match $regx;  push @lines => __LINE__;
+                item 'b';               push @lines => __LINE__;
+                item 'aa';              push @lines => __LINE__;
+                end;
+            },
+            "items do not all match, and diag reflects all issues, and in order"
+        );
+    };
+    like(
+        $events,
+        array {
+            fail_events Ok => {pass => 0};
+            event Diag => {
+                message => table(
+                    header => [qw/PATH GOT OP CHECK LNs/],
+                    rows   => [
+                        ['', "$array", '', "<ARRAY>", ($lines[0] - 1) . ", " . ($lines[-1] + 2)],
+                        ['[0]', 'a',   '=~',      $regx,              $lines[0]],
+                        ['[0]', 'a',   'eq',      'b',                $lines[1]],
+                        ['[1]', 'aa',  '=~',      $regx,              $lines[0]],
+                        ['[2]', 'aaa', '=~',      $regx,              $lines[0]],
+                        ['[2]', 'aaa', '!exists', '<DOES NOT EXIST>', ''],
+                    ],
+                ),
+            };
+
+        },
+        "items do not all match, and diag reflects all issues, and in order"
+    );
+};
+
+subtest all_keys_and_vals => sub {
+    is(
+        {a => 'a', 'aa' => 'aa', 'aaa' => 'aaa'},
+        hash {
+            all_values match qr/^a+$/;
+            all_keys match qr/^a+$/;
+            field a   => 'a';
+            field aa  => 'aa';
+            field aaa => 'aaa';
+        },
+        "All items match regex"
+    );
+
+    my @lines;
+    my $hash = {a => 'a', 'aa' => 'aa', 'aaa' => 'aaa'};
+    my $regx = qr/^b+$/;
+    my $events = intercept {
+        is(
+            $hash,
+            hash {
+                all_keys match $regx;   push @lines => __LINE__;
+                all_vals match $regx;   push @lines => __LINE__;
+                field aa => 'aa';       push @lines => __LINE__;
+                field b  => 'b';        push @lines => __LINE__;
+                end;
+            },
+            "items do not all match, and diag reflects all issues, and in order"
+        );
+    };
+    like(
+        $events,
+        array {
+            fail_events Ok => {pass => 0};
+            event Diag => {
+                message => table(
+                    header => [qw/PATH GOT OP CHECK LNs/],
+                    rows   => [
+                        ['',            $hash,              '',        '<HASH>',           join(', ', $lines[0] - 1, $lines[-1] + 2)],
+                        ['{aa} <KEY>',  'aa',               '=~',      $regx,              $lines[0]],
+                        ['{aa}',        'aa',               '=~',      $regx,              $lines[1]],
+                        ['{b}',         '<DOES NOT EXIST>', '',        'b',                $lines[3]],
+                        ['{a} <KEY>',   'a',                '=~',      $regx,              $lines[0]],
+                        ['{a}',         'a',                '=~',      $regx,              $lines[1]],
+                        ['{a}',         'a',                '!exists', '<DOES NOT EXIST>', '',],
+                        ['{aaa} <KEY>', 'aaa',              '=~',      $regx,              $lines[0]],
+                        ['{aaa}',       'aaa',              '=~',      $regx,              $lines[1]],
+                        ['{aaa}',       'aaa',              '!exists', '<DOES NOT EXIST>', ''],
+                    ],
+                ),
+            };
+        },
+        "items do not all match, and diag reflects all issues, and in order"
+    );
+};
+
+
+done_testing;

--- a/t/v1/Tools/Defer.t
+++ b/t/v1/Tools/Defer.t
@@ -1,0 +1,188 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use strict;
+use warnings;
+use Test2::Tools::Defer;
+
+my $file = __FILE__;
+
+my $START_LINE;
+BEGIN {
+    $START_LINE = __LINE__;
+    def ok => (1, "truth");
+    def is => (1, 1, "1 is 1");
+    def is => ({}, {}, "hash is hash");
+
+    def ok => (0, 'lies');
+    def is => (0, 1, "1 is not 0");
+    def is => ({}, [], "a hash is not an array");
+}
+
+use Test2::Bundle::Extended -target => 'Test2::Tools::Defer';
+
+sub capture(&) {
+    my $code = shift;
+
+    my ($err, $out) = ("", "");
+
+    my ($ok, $e);
+    {
+        local *STDOUT;
+        local *STDERR;
+
+        ($ok, $e) = Test2::Util::try(sub {
+            open(STDOUT, '>', \$out) or die "Failed to open a temporary STDOUT: $!";
+            open(STDERR, '>', \$err) or die "Failed to open a temporary STDERR: $!";
+
+            $code->();
+        });
+    }
+
+    die $e unless $ok;
+
+    return {
+        STDOUT => $out,
+        STDERR => $err,
+    };
+}
+
+is(
+    intercept { do_def },
+    array {
+        filter_items { grep { $_->isa('Test2::Event::Ok') } @_ };
+
+        event Ok => sub {
+            call pass => 1;
+            call name => 'truth';
+            prop file => "(eval in Test2::Tools::Defer) " . __FILE__;
+            prop line => $START_LINE + 1;
+            prop package => __PACKAGE__;
+        };
+
+        event Ok => sub {
+            call pass => 1;
+            call name => '1 is 1';
+            prop file => "(eval in Test2::Tools::Defer) " . __FILE__;
+            prop line => $START_LINE + 2;
+            prop package => __PACKAGE__;
+        };
+
+        event Ok => sub {
+            call pass => 1;
+            call name => 'hash is hash';
+            prop file => "(eval in Test2::Tools::Defer) " . __FILE__;
+            prop line => $START_LINE + 3;
+            prop package => __PACKAGE__;
+        };
+
+        event Ok => sub {
+            call pass => 0;
+            call name => 'lies';
+            prop file => "(eval in Test2::Tools::Defer) " . __FILE__;
+            prop line => $START_LINE + 5;
+            prop package => __PACKAGE__;
+        };
+
+        event Ok => sub {
+            call pass => 0;
+            call name => '1 is not 0';
+            prop file => "(eval in Test2::Tools::Defer) " . __FILE__;
+            prop line => $START_LINE + 6;
+            prop package => __PACKAGE__;
+        };
+
+        event Ok => sub {
+            call pass => 0;
+            call name => 'a hash is not an array';
+            prop file => "(eval in Test2::Tools::Defer) " . __FILE__;
+            prop line => $START_LINE + 7;
+            prop package => __PACKAGE__;
+        };
+
+        end;
+    },
+    "got expected events"
+);
+
+def ok => (1, "truth");
+def is => (1, 1, "1 is 1");
+def is => ({}, {}, "hash is hash");
+
+# Actually run some that pass
+do_def();
+
+like(
+    dies { do_def() },
+    qr/No tests to run/,
+    "Fails if there are no tests"
+);
+
+my $line1 = __LINE__ + 1;
+sub oops { die 'oops' }
+
+my $line2 = __LINE__ + 1;
+def oops => (1);
+like( dies { do_def() }, <<EOT, "Exceptions in the test are propogated");
+Exception: oops at $file line $line1.
+--eval--
+package main;
+# line $line2 "(eval in Test2::Tools::Defer) $file"
+&oops(\@\$args);
+1;
+--------
+Tool:   oops
+Caller: main, $file, $line2
+\$args:  [
+          1
+        ];
+EOT
+
+
+{
+    {
+        package Foo;
+        main::def ok => (1, "pass");
+    }
+    def ok => (1, "pass");
+
+    my $new_exit = 0;
+    my $out = capture { Test2::Tools::Defer::_verify(undef, 0, \$new_exit) };
+
+    is($new_exit, 255, "exit set to 255 due to unrun tests");
+    like(
+        $out->{STDOUT},
+        qr/not ok - deferred tests were not run/,
+        "Got failed STDOUT line"
+    );
+
+    like(
+        $out->{STDERR},
+        qr/# 'main' has deferred tests that were never run/,
+        "We see that main failed"
+    );
+
+    like(
+        $out->{STDERR},
+        qr/# 'Foo' has deferred tests that were never run/,
+        "We see that Foo failed"
+    );
+}
+
+{
+    local $? = 101;
+    def ok => (1, "pass");
+    my $out = capture { Test2::Tools::Defer::_verify() };
+    is($?, 101, "did not change exit code");
+    like(
+        $out->{STDOUT},
+        qr/not ok - deferred tests were not run/,
+        "Got failed STDOUT line"
+    );
+
+    like(
+        $out->{STDERR},
+        qr/# 'main' has deferred tests that were never run/,
+        "We see that main failed"
+    );
+}
+
+done_testing;

--- a/t/v1/Tools/Encoding.t
+++ b/t/v1/Tools/Encoding.t
@@ -1,0 +1,53 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Tools::Encoding';
+
+use File::Temp qw/tempfile/;
+
+{
+    package Temp;
+    use Test2::Tools::Encoding;
+
+    main::imported_ok(qw/set_encoding/);
+}
+
+my $warnings;
+intercept {
+    $warnings = warns {
+        use utf8;
+
+        my ($fh, $name);
+        my $ct = 100;
+        until ($fh) {
+            --$ct or die "Failed to get temp file after 100 tries";
+            ($fh, $name) = eval { tempfile() };
+        }
+
+        Test2::API::test2_stack->top->format(
+            Test2::Formatter::TAP->new(
+                handles => [$fh, $fh, $fh],
+            ),
+        );
+
+        set_encoding('utf8');
+        ok(1, '†');
+
+        unlink($name) or print STDERR "Could not remove temp file $name: $!\n";
+    };
+};
+
+ok(!$warnings, "set_encoding worked");
+
+my $exception;
+intercept {
+    $exception = dies {
+        set_encoding('utf8');
+    };
+};
+
+like(
+    $exception,
+    qr/Unable to set encoding on formatter '<undef>'/,
+    "Cannot set encoding without a formatter"
+);
+
+done_testing;

--- a/t/v1/Tools/Event.t
+++ b/t/v1/Tools/Event.t
@@ -1,0 +1,14 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended;
+
+imported_ok('gen_event');
+
+my $e = gen_event Ok => (pass => 1, name => 'foo');
+my $c = event Ok => {pass => 1, name => 'foo', trace => {frame => [__PACKAGE__, __FILE__, __LINE__ - 1]}};
+like($e, $c, "Generated event");
+
+$e = gen_event '+Test2::Event::Ok' => (pass => 1, name => 'foo');
+$c = event Ok => {pass => 1, name => 'foo', trace => {frame => [__PACKAGE__, __FILE__, __LINE__ - 1]}};
+like($e, $c, "Generated event long-form");
+
+done_testing;

--- a/t/v1/Tools/Exception.t
+++ b/t/v1/Tools/Exception.t
@@ -1,0 +1,46 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Tools::Exception';
+
+{
+    package Foo;
+    use Test2::Tools::Exception qw/dies lives try_ok/;
+    ::imported_ok(qw/dies lives try_ok/);
+}
+
+use Test2::API qw/intercept/;
+
+like(
+    dies { die 'xyz' },
+    qr/xyz/,
+    "Got exception"
+);
+
+is(dies { 0 }, undef, "no exception");
+
+{
+    local $@ = 'foo';
+    ok(lives { 0 }, "it lives!");
+    is($@, "foo", "did not change \$@");
+}
+
+ok(!lives { die 'xxx' }, "it died");
+like($@, qr/xxx/, "Exception is available");
+
+try_ok { 0 } "No Exception from try_ok";
+
+my $err;
+is(
+    intercept { try_ok { die 'abc' } "foo"; $err = $@; },
+    array {
+        fail_events Ok => sub {
+            call name => "foo";
+            call pass => 0;
+        };
+        event Diag => sub { msg => match qr/abc/; };
+    },
+    "Got failure + diag from try_ok"
+);
+
+like($err, qr/abc/, '$@ has the exception');
+
+done_testing;

--- a/t/v1/Tools/Exports.t
+++ b/t/v1/Tools/Exports.t
@@ -1,0 +1,32 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Tools::Exports';
+
+{
+    package Temp;
+    use Test2::Tools::Exports;
+
+    imported_ok(qw/imported_ok not_imported_ok/);
+    not_imported_ok(qw/xyz/);
+}
+
+like(
+    intercept { imported_ok('x') },
+    array {
+        fail_events Ok => { pass => 0 };
+        event Diag => { message => "'x' was not imported." };
+        end;
+    },
+    "Failed, x is not imported"
+);
+
+like(
+    intercept { not_imported_ok('ok') },
+    array {
+        fail_events Ok => { pass => 0 };
+        event Diag => { message => "'ok' was imported." };
+        end;
+    },
+    "Failed, 'ok' is imported"
+);
+
+done_testing;

--- a/t/v1/Tools/Grab.t
+++ b/t/v1/Tools/Grab.t
@@ -1,0 +1,36 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Util::Grabber';
+
+use Test2::Tools::Grab;
+
+ok(1, "initializing");
+
+my $grab = grab();
+ok(1, "pass");
+my $one = $grab->events;
+ok(0, "fail");
+my $events = $grab->finish;
+
+is(@$one, 1, "Captured 1 event");
+is(@$events, 3, "Captured 3 events");
+
+like(
+    $one,
+    array {
+        event Ok => { pass => 1 };
+    },
+    "Got expected event"
+);
+
+like(
+    $events,
+    array {
+        event Ok => { pass => 1 };
+        event Ok => { pass => 0 };
+        event Diag => { };
+        end;
+    },
+    "Got expected events"
+);
+
+done_testing;

--- a/t/v1/Tools/Mock.t
+++ b/t/v1/Tools/Mock.t
@@ -1,0 +1,250 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Compare::Custom';
+
+use Test2::Tools::Mock qw{
+    mock_obj mock_class
+    mock_do  mock_build
+    mock_accessor mock_accessors
+    mock_getter   mock_getters
+    mock_setter   mock_setters
+    mock_building
+};
+
+use Scalar::Util qw/reftype blessed/;
+
+imported_ok qw{
+    mock_obj mock_class
+    mock_do  mock_build
+    mock_accessor mock_accessors
+    mock_getter   mock_getters
+    mock_setter   mock_setters
+    mock_building
+};
+
+subtest generators => sub {
+    # These are all thin wrappers around HashBase subs, we just test that we
+    # get subs, HashBase subtest that the thing we are wrapping produce the
+    # correct type of subs.
+
+    my %accessors = mock_accessors qw/foo bar baz/;
+    is([sort keys %accessors], [sort qw/foo bar baz/], "All 3 keys set");
+    is(reftype($accessors{$_}), 'CODE', "sub as value for $_") for qw/foo bar baz/;
+
+    is(reftype(mock_accessor('xxx')), 'CODE', "Generated an accessor");
+
+    my %getters = mock_getters 'get_' => qw/foo bar baz/;
+    is([sort keys %getters], [sort qw/get_foo get_bar get_baz/], "All 3 keys set");
+    is(reftype($getters{"get_$_"}), 'CODE', "sub as value for get_$_") for qw/foo bar baz/;
+
+    is(reftype(mock_getter('xxx')), 'CODE', "Generated a getter");
+
+    my %setters = mock_setters 'set_' => qw/foo bar baz/;
+    is([sort keys %setters], [sort qw/set_foo set_bar set_baz/], "All 3 keys set");
+    is(reftype($setters{"set_$_"}), 'CODE', "sub as value for set_$_") for qw/foo bar baz/;
+
+    is(reftype(mock_setter('xxx')), 'CODE', "Generated a setter");
+};
+
+subtest mocks => sub {
+    my $inst;
+    my $control;
+    my $class;
+
+    my $object = sub {
+        $inst      = mock_obj({}, add_constructor => [new => 'hash']);
+        ($control) = mocked($inst);
+        $class     = $control->class;
+    };
+
+    my $package = sub {
+        $control = mock_class('Fake::Class', add_constructor => [new => 'hash']);
+        $class   = $control->class;
+        $inst    = $class->new;
+    };
+
+    for my $case ($object, $package) {
+        $case->();
+
+        isa_ok($control, 'Test2::Mock');
+        isa_ok($inst, $class);
+        ok($class, "got a class");
+
+        subtest mocked => sub {
+            ok(!mocked('main'), "main class is not mocked");
+            is(mocked($inst), 1, "Only 1 control object for this instance");
+            my ($c) = mocked($inst);
+            ref_is($c, $control, "got correct control when checking if an object was mocked");
+
+            my $control2 = mock_class($control->class);
+
+            is(mocked($inst), 2, "now 2 control objects for this instance");
+            my ($c1, $c2) = mocked($inst);
+            ref_is($c1, $control, "got first control");
+            ref_is($c2, $control2, "got second control");
+        };
+
+        subtest build_and_do => sub {
+            like(
+                dies { mock_build(undef, sub { 1 }) },
+                qr/mock_build requires a Test2::Mock object as its first argument/,
+                "control is required",
+            );
+
+            like(
+                dies { mock_build($control, undef) },
+                qr/mock_build requires a coderef as its second argument/,
+                "Must have a coderef to build"
+            );
+
+            like(
+                dies { mock_do add => (foo => sub { 'foo' }) },
+                qr/Not currently building a mock/,
+                "mock_do outside of a build fails"
+            );
+
+            ok(!mock_building, "no mock is building");
+            my $ran = 0;
+            mock_build $control => sub {
+                is(mock_building, $control, "Building expected control");
+
+                like(
+                    dies { mock_do 'foo' => 1 },
+                    qr/'foo' is not a valid action for mock_do\(\)/,
+                    "invalid action"
+                );
+
+                mock_do add => (
+                    foo => sub { 'foo' },
+                );
+
+                can_ok($inst, 'foo');
+                is($inst->foo, 'foo', "added sub");
+
+                $ran++;
+            };
+
+            ok(!mock_building, "no mock is building");
+            ok($ran, "build sub completed successfully");
+        };
+    }
+};
+
+subtest mock_obj => sub {
+    my $ref = {};
+    my $obj = mock_obj $ref;
+    is($ref, $obj, "blessed \$ref");
+    is($ref->foo(1), 1, "is vivifying object");
+
+    my $ran = 0;
+    $obj = mock_obj(sub { $ran++ });
+    is($ref->foo(1), 1, "is vivifying object");
+    is($ran, 1, "code ran");
+
+    $obj = mock_obj { foo => 'foo' } => (
+        add => [ bar => sub { 'bar' }],
+    );
+
+    is($obj->foo, 'foo', "got value for foo");
+    is($obj->bar, 'bar', "got value for bar");
+
+    my ($c) = mocked($obj);
+    ok($c, "got control");
+    is($obj->{'~~MOCK~CONTROL~~'}, $c, "control is stashed");
+
+    my $class = $c->class;
+    my $file = $c->file;
+    ok($INC{$file}, "Mocked Loaded");
+
+    $obj = undef;
+    $c = undef;
+
+    ok(!$INC{$file}, "Not loaded anymore");
+};
+
+subtest mock_class_basic => sub {
+    my $c = mock_class 'Fake';
+    isa_ok($c, 'Test2::Mock');
+    is($c->class, 'Fake', "Control for 'Fake'");
+    $c = undef;
+
+    # Check with an instance
+    my $i = bless {}, 'Fake';
+    $c = mock_class $i;
+    isa_ok($c, 'Test2::Mock');
+    is($c->class, 'Fake', "Control for 'Fake'");
+
+    is([mocked($i)], [$c], "is mocked");
+};
+
+subtest post => sub {
+    ok(!"Fake$_"->can('check'), "mock $_ did not leak") for 1 .. 5;
+};
+
+ok(!"Fake$_"->can('check'), "mock $_ did not leak") for 1 .. 5;
+
+subtest just_mock => sub {
+    like(
+        dies { mock undef },
+        qr/undef is not a valid first argument to mock/,
+        "Cannot mock undef"
+    );
+
+    like(
+        dies { mock 'fakemethodname' },
+        qr/'fakemethodname' does not look like a package name, and is not a valid control method/,
+        "invalid mock arg"
+    );
+
+    my $c = mock 'Fake';
+    isa_ok($c, 'Test2::Mock');
+    is($c->class, 'Fake', "mocked correct class");
+    mock $c => sub {
+        mock add => (foo => sub { 'foo' });
+    };
+
+    can_ok('Fake', 'foo');
+    is(Fake->foo(), 'foo', "mocked build, mocked do");
+
+    my $o = mock;
+    ok(blessed($o), "created object");
+    $c = mocked($o);
+    ok($c, "got control");
+
+    $o = mock { foo => 'foo' };
+    is($o->foo, 'foo', "got the expected result");
+    is($o->{foo}, 'foo', "blessed the reference");
+
+    $c = mock $o;
+    isa_ok($o, $c->class);
+
+
+    my $code = mock accessor => 'foo';
+    ok(reftype($code), 'CODE', "Generated an accessor");
+};
+
+subtest handlers => sub {
+    Test2::Tools::Mock->add_handler(__PACKAGE__,
+        sub {
+            is(
+                {@_},
+                {
+                    class   => 'Foo',
+                    caller  => T(),
+                    builder => T(),
+                    args    => T(),
+                }
+            );
+            1;
+        }
+    );
+
+    is(
+        dies {
+            mock Foo => {add => ['xxx' => sub { 'xxx' }]}
+        },
+        undef,
+        "did not die"
+    );
+};
+
+done_testing;

--- a/t/v1/Tools/Ref.t
+++ b/t/v1/Tools/Ref.t
@@ -1,0 +1,95 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Tools::Ref';
+
+{
+    package Temp;
+    use Test2::Tools::Ref;
+
+    main::imported_ok(qw/ref_ok ref_is ref_is_not/);
+}
+
+like(
+    intercept {
+        ref_ok({});
+        ref_ok({}, 'HASH', 'pass');
+        ref_ok([], 'ARRAY', 'pass');
+        ref_ok({}, 'ARRAY', 'fail');
+        ref_ok('xxx');
+        ref_ok('xxx', 'xxx');
+    },
+    array {
+        event Ok => { pass => 1 };
+        event Ok => { pass => 1 };
+        event Ok => { pass => 1 };
+
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => qr/'HASH\(.*\)' is not a 'ARRAY' reference/ };
+
+        fail_events Ok => { pass => 0 };
+        event Diag => { message => qr/'xxx' is not a reference/ };
+
+        fail_events Ok => { pass => 0 };
+        event Diag => { message => qr/'xxx' is not a reference/ };
+
+        end;
+    },
+    "ref_ok tests"
+);
+
+my $x = [];
+my $y = [];
+like(
+    intercept {
+        ref_is($x, $x, 'same x');
+        ref_is($x, $y, 'not same');
+
+        ref_is_not($x, $y, 'not same');
+        ref_is_not($y, $y, 'same y');
+
+        ref_is('x', $x, 'no ref');
+        ref_is($x, 'x', 'no ref');
+
+        ref_is_not('x', $x, 'no ref');
+        ref_is_not($x, 'x', 'no ref');
+
+        ref_is(undef, $x, 'undef');
+        ref_is($x, undef, 'undef');
+
+        ref_is_not(undef, $x, 'undef');
+        ref_is_not($x, undef, 'undef');
+    },
+    array {
+        event Ok => sub { call pass => 1 };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "'$x' is not the same reference as '$y'" };
+
+        event Ok => sub { call pass => 1 };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "'$y' is the same reference as '$y'" };
+
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "First argument 'x' is not a reference" };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "Second argument 'x' is not a reference" };
+
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "First argument 'x' is not a reference" };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "Second argument 'x' is not a reference" };
+
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "First argument '<undef>' is not a reference" };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "Second argument '<undef>' is not a reference" };
+
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "First argument '<undef>' is not a reference" };
+        fail_events Ok => sub { call pass => 0 };
+        event Diag => { message => "Second argument '<undef>' is not a reference" };
+
+        end;
+    },
+    "Ref checks"
+);
+
+done_testing;

--- a/t/v1/Tools/Subtest.t
+++ b/t/v1/Tools/Subtest.t
@@ -1,0 +1,424 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Tools::Subtest';
+
+use Test2::Tools::Subtest qw/subtest_streamed subtest_buffered/;
+
+
+use File::Temp qw/tempfile/;
+
+# A bug in older perls causes a strange error AFTER the program appears to be
+# done if this test is run.
+# "Size magic not implemented."
+if ($] > 5.020000) {
+    like(
+        intercept {
+            subtest_streamed 'foo' => sub {
+                my ($fh, $name) = tempfile;
+                print $fh <<"                EOT";
+                    use Test2::Bundle::Extended;
+                    BEGIN { skip_all 'because' }
+                    1;
+                EOT
+                close($fh);
+                do $name;
+                unlink($name) or warn "Could not remove temp file $name: $!";
+                die $@ if $@;
+                die "Ooops";
+            };
+        },
+        subset {
+            event Note => { message => 'Subtest: foo' };
+            event Subtest => sub {
+                field pass => 1;
+                field name => 'Subtest: foo';
+                field subevents => subset {
+                    event Plan => { directive => 'SKIP', reason => 'because' };
+                };
+            }
+        },
+        "skip_all in BEGIN inside a subtest works"
+    );
+}
+
+subtest_streamed 'hub tests' => sub {
+    my $hub = Test2::API::test2_stack->top;
+    isa_ok($hub, 'Test2::Hub', 'Test2::Hub::Subtest');
+
+    my $todo = todo "testing parent_todo";
+    subtest_streamed 'inner hub tests' => sub {
+        my $ihub = Test2::API::test2_stack->top;
+        isa_ok($ihub, 'Test2::Hub', 'Test2::Hub::Subtest');
+    };
+};
+
+like(
+    intercept {
+        subtest_streamed 'foo' => sub {
+            subtest_buffered 'bar' => sub {
+                ok(1, "pass");
+            };
+        };
+    },
+    subset {
+        event Note => { message => 'Subtest: foo' };
+        event Subtest => sub {
+            field pass => 1;
+            field name => 'Subtest: foo';
+            field subevents => subset {
+                event Subtest => sub {
+                    field pass => 1;
+                    field name => 'bar';
+                    field subevents => subset {
+                        event Ok => sub {
+                            field name => 'pass';
+                            field pass => 1;
+                        };
+                    };
+                };
+            };
+        };
+    },
+    "Can nest subtests"
+);
+
+my @lines = ();
+like(
+    intercept {
+        push @lines => __LINE__ + 4;
+        subtest_streamed 'foo' => sub {
+            push @lines => __LINE__ + 1;
+            ok(1, "pass");
+        };
+    },
+    subset {
+        event Note => { message => 'Subtest: foo' };
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 1;
+            field name => 'Subtest: foo';
+            field subevents => subset {
+                event Ok => sub {
+                    prop file => __FILE__;
+                    prop line => $lines[1];
+                    field name => 'pass';
+                    field pass => 1;
+                };
+            };
+        };
+    },
+    "Got events for passing subtest"
+);
+
+@lines = ();
+like(
+    intercept {
+        push @lines => __LINE__ + 4;
+        subtest_streamed 'foo' => sub {
+            push @lines => __LINE__ + 1;
+            ok(0, "fail");
+        };
+    },
+    subset {
+        event Note => { message => 'Subtest: foo' };
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 0;
+            field name => 'Subtest: foo';
+            field subevents => subset {
+                event Ok => sub {
+                    prop file => __FILE__;
+                    prop line => $lines[1];
+                    field name => 'fail';
+                    field pass => 0;
+                };
+            };
+        };
+    },
+    "Got events for failing subtest"
+);
+
+@lines = ();
+like(
+    intercept {
+        push @lines => __LINE__ + 5;
+        subtest_streamed 'foo' => sub {
+            push @lines => __LINE__ + 1;
+            ok(1, "pass");
+            done_testing;
+        };
+    },
+    subset {
+        event Note => { message => 'Subtest: foo' };
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 1;
+            field name => 'Subtest: foo';
+            field subevents => subset {
+                event Ok => sub {
+                    prop file => __FILE__;
+                    prop line => $lines[1];
+                    field name => 'pass';
+                    field pass => 1;
+                };
+                event Plan => { max => 1 };
+            };
+        };
+    },
+    "Can use done_testing"
+);
+
+@lines = ();
+like(
+    intercept {
+        push @lines => __LINE__ + 5;
+        subtest_streamed 'foo' => sub {
+            plan 1;
+            push @lines => __LINE__ + 1;
+            ok(1, "pass");
+        };
+    },
+    subset {
+        event Note => { message => 'Subtest: foo' };
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 1;
+            field name => 'Subtest: foo';
+            field subevents => subset {
+                event Plan => { max => 1 };
+                event Ok => sub {
+                    prop file => __FILE__;
+                    prop line => $lines[1];
+                    field name => 'pass';
+                    field pass => 1;
+                };
+            };
+        };
+    },
+    "Can plan"
+);
+
+@lines = ();
+like(
+    intercept {
+        push @lines => __LINE__ + 5;
+        subtest_streamed 'foo' => sub {
+            skip_all 'bleh';
+            push @lines => __LINE__ + 1;
+            ok(1, "pass");
+        };
+    },
+    subset {
+        event Note => { message => 'Subtest: foo' };
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 1;
+            field name => 'Subtest: foo';
+            field subevents => subset {
+                event Plan => { directive => 'SKIP', reason => 'bleh' };
+            };
+        };
+    },
+    "Can skip_all"
+);
+
+@lines = ();
+like(
+    intercept {
+        subtest_streamed 'foo' => sub {
+            bail_out 'cause';
+            ok(1, "should not see this");
+        };
+    },
+    subset {
+        event Note => { message => 'Subtest: foo' };
+        event Bail => { reason => 'cause' };
+    },
+    "Can bail out"
+);
+
+@lines = ();
+like(
+    intercept {
+        push @lines => __LINE__ + 4;
+        subtest_buffered 'foo' => sub {
+            push @lines => __LINE__ + 1;
+            ok(1, "pass");
+        };
+    },
+    subset {
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 1;
+            field name => 'foo';
+            field subevents => subset {
+                event Ok => sub {
+                    prop file => __FILE__;
+                    prop line => $lines[1];
+                    field name => 'pass';
+                    field pass => 1;
+                };
+            };
+        };
+    },
+    "Got events for passing subtest"
+);
+
+@lines = ();
+like(
+    intercept {
+        push @lines => __LINE__ + 4;
+        subtest_buffered 'foo' => sub {
+            push @lines => __LINE__ + 1;
+            ok(0, "fail");
+        };
+    },
+    subset {
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 0;
+            field name => 'foo';
+            field subevents => subset {
+                event Ok => sub {
+                    prop file => __FILE__;
+                    prop line => $lines[1];
+                    field name => 'fail';
+                    field pass => 0;
+                };
+            };
+        };
+    },
+    "Got events for failing subtest"
+);
+
+@lines = ();
+like(
+    intercept {
+        push @lines => __LINE__ + 5;
+        subtest_buffered 'foo' => sub {
+            push @lines => __LINE__ + 1;
+            ok(1, "pass");
+            done_testing;
+        };
+    },
+    subset {
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 1;
+            field name => 'foo';
+            field subevents => subset {
+                event Ok => sub {
+                    prop file => __FILE__;
+                    prop line => $lines[1];
+                    field name => 'pass';
+                    field pass => 1;
+                };
+                event Plan => { max => 1 };
+            };
+        };
+    },
+    "Can use done_testing"
+);
+
+@lines = ();
+like(
+    intercept {
+        push @lines => __LINE__ + 5;
+        subtest_buffered 'foo' => sub {
+            plan 1;
+            push @lines => __LINE__ + 1;
+            ok(1, "pass");
+        };
+    },
+    subset {
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 1;
+            field name => 'foo';
+            field subevents => subset {
+                event Plan => { max => 1 };
+                event Ok => sub {
+                    prop file => __FILE__;
+                    prop line => $lines[1];
+                    field name => 'pass';
+                    field pass => 1;
+                };
+            };
+        };
+    },
+    "Can plan"
+);
+
+@lines = ();
+like(
+    intercept {
+        push @lines => __LINE__ + 5;
+        subtest_buffered 'foo' => sub {
+            skip_all 'bleh';
+            push @lines => __LINE__ + 1;
+            ok(1, "pass");
+        };
+    },
+    subset {
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 1;
+            field name => 'foo';
+            field subevents => subset {
+                event Plan => { directive => 'SKIP', reason => 'bleh' };
+            };
+        };
+    },
+    "Can skip_all"
+);
+
+@lines = ();
+like(
+    intercept {
+        subtest_buffered 'foo' => sub {
+            bail_out 'cause';
+            ok(1, "should not see this");
+        };
+    },
+    subset {
+        event Bail => { reason => 'cause' };
+    },
+    "Can bail out"
+);
+
+@lines = ();
+my $xyz = 0;
+like(
+    intercept {
+        push @lines => __LINE__ + 5;
+        subtest_buffered 'foo' => {manual_skip_all => 1}, sub {
+            skip_all 'bleh';
+            $xyz = 1;
+            return;
+        };
+    },
+    subset {
+        event Subtest => sub {
+            prop file => __FILE__;
+            prop line => $lines[0];
+            field pass => 1;
+            field name => 'foo';
+            field subevents => subset {
+                event Plan => { directive => 'SKIP', reason => 'bleh' };
+            };
+        };
+    },
+    "Can skip_all"
+);
+ok($xyz, "skip_all did not auto-abort");
+
+done_testing;

--- a/t/v1/Tools/Target.t
+++ b/t/v1/Tools/Target.t
@@ -1,0 +1,14 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended;
+
+use Test2::Tools::Target 'Test2::Tools::Target';
+
+is($CLASS, 'Test2::Tools::Target', "set default var");
+is(CLASS(), 'Test2::Tools::Target', "set default const");
+
+use Test2::Tools::Target FOO => 'Test2::Tools::Target';
+
+is($FOO,  'Test2::Tools::Target', "set custom var");
+is(FOO(), 'Test2::Tools::Target', "set custom const");
+
+done_testing;

--- a/t/v1/Tools/Warnings.t
+++ b/t/v1/Tools/Warnings.t
@@ -1,0 +1,63 @@
+BEGIN { $ENV{T2_NO_PIN_CHECK} = 1 }
+use Test2::Bundle::Extended -target => 'Test2::Tools::Warnings';
+
+{
+    package Foo;
+    use Test2::Tools::Warnings qw/warns warning warnings no_warnings/;
+    ::imported_ok(qw/warns warning warnings no_warnings/);
+}
+
+is(warns { 0 }, 0, "no warnings");
+is(warns { warn 'a' }, 1, "1 warning");
+is(warns { warn 'a' for 1 .. 4 }, 4, "4 warnings");
+
+ok(no_warnings { 0 }, "no warnings");
+ok(!no_warnings { warn 'a' }, "warnings");
+
+is(
+    warnings { 0 },
+    [],
+    "Empty arrayref"
+);
+
+is(
+    warnings { warn "a\n" for 1 .. 4 },
+    [ map "a\n", 1 .. 4 ],
+    "4 warnings in arrayref"
+);
+
+is(
+    warning { warn "xyz\n" },
+    "xyz\n",
+    "Got expected warning"
+);
+
+is(
+    warning { 0 },
+    undef,
+    "No warning"
+);
+
+my ($events, $warn);
+$events = intercept {
+    $warn = warning {
+        warning { warn "a\n"; warn "b\n" };
+    };
+};
+
+like(
+    $warn,
+    qr/Extra warnings in warning \{ \.\.\. \}/,
+    "Got warning about extra warnings"
+);
+
+like(
+    $events,
+    array {
+        event Note => { message => "a\n" };
+        event Note => { message => "b\n" };
+    },
+    "Got warnings as notes."
+);
+
+done_testing;


### PR DESCRIPTION
Fixes #69 


This will not pass on travis/appveyor until new Importer is released as stable.