### PR TITLE
Change Test2::Plugin::UTF8 to not alter STDOUT/ERR.

### DIFF
--- a/lib/Test2/Plugin/UTF8.pm
+++ b/lib/Test2/Plugin/UTF8.pm
@@ -16,10 +16,6 @@ sub import {
     require utf8;
     utf8->import;
 
-    # Set STDERR and STDOUT
-    binmode(STDERR, ':utf8');
-    binmode(STDOUT, ':utf8');
-
     # Set the output formatters to use utf8
     test2_add_callback_post_load(sub {
         my $stack = test2_stack;
@@ -49,35 +45,34 @@ __END__
 
 =head1 NAME
 
-Test2::Plugin::UTF8 - Test2 plugin that enables utf8.
+Test2::Plugin::UTF8 - Test2 plugin to test with utf8.
 
 =head1 DESCRIPTION
 
-When used, this plugin will turn on the utf8 pragma, set STDERR and STDOUT to
-use utf8, and update the Test2 output formatter to use utf8.
+When used, this plugin will make tests work with utf8. This includes
+turning on the utf8 pragma and updating the Test2 output formatter to
+use utf8.
 
 =head1 SYNOPSIS
 
     use Test2::Plugin::UTF8;
 
-This is the same as
+This is similar to:
 
     use utf8;
     BEGIN {
         require Test2::Tools::Encoding;
         Test2::Tools::Encoding::set_encoding('utf8');
-        binmode(STDERR, ':utf8');
-        binmode(STDOUT, ':utf8');
     }
 
 =head1 NOTES
 
-This module sets output handles to have the ':utf8' output layer. Some might
-prefer ':encoding(utf-8)' which is more strict about verifying characters.
-There is a debate about weather or not encoding to utf8 from perl internals can
-ever fail, so it may not matter. This was also chosen because the alternative
-causes threads to segfault, see
-L<perlbug 31923|https://rt.perl.org/Public/Bug/Display.html?id=31923>.
+This module currently sets output handles to have the ':utf8' output
+layer. Some might prefer ':encoding(utf-8)' which is more strict about
+verifying characters.  There is a debate about weather or not encoding
+to utf8 from perl internals can ever fail, so it may not matter. This
+was also chosen because the alternative causes threads to segfault,
+see L<perlbug 31923|https://rt.perl.org/Public/Bug/Display.html?id=31923>.
 
 =head1 SOURCE
 

--- a/t/modules/Bundle/Extended.t
+++ b/t/modules/Bundle/Extended.t
@@ -65,18 +65,12 @@ subtest warnings => sub {
 subtest utf8 => sub {
     ok(utf8::is_utf8("癸"), "utf8 pragma is on");
 
-    my $layers = { map {$_ => 1} PerlIO::get_layers(STDERR) };
-    ok($layers->{utf8}, "utf8 is on for STDERR");
-
-    $layers = { map {$_ => 1} PerlIO::get_layers(STDOUT) };
-    ok($layers->{utf8}, "utf8 is on for STDOUT");
-
     # -2 cause the subtest adds to the stack
     my $format = test2_stack()->[-2]->format;
     my $handles = $format->handles;
     for my $hn (0 .. @$handles) {
         my $h = $handles->[$hn] || next;
-        $layers = { map {$_ => 1} PerlIO::get_layers($h) };
+        my $layers = { map {$_ => 1} PerlIO::get_layers($h) };
         ok($layers->{utf8}, "utf8 is on for formatter handle $hn");
     }
 };

--- a/t/modules/Plugin/UTF8.t
+++ b/t/modules/Plugin/UTF8.t
@@ -2,25 +2,43 @@ use strict;
 use warnings;
 # HARNESS-NO-FORMATTER
 
+# Store the default STDOUT and STDERR IO layers for later testing.
+# This must happen before we load anything else.
+use PerlIO ();
+my %Layers;
+
+sub get_layers {
+    my $fh = shift;
+    return { map {$_ => 1} PerlIO::get_layers($fh) };
+}
+
+BEGIN {
+    $Layers{STDERR} = get_layers(*STDERR);
+    $Layers{STDOUT} = get_layers(*STDOUT);
+}
+
 use Test2::Plugin::UTF8;
-use Test2::Tools::Basic qw/ok done_testing/;
+use Test2::Tools::Basic;
+use Test2::Tools::Compare;
+use Test2::API qw(test2_stack);
 
-use PerlIO;
+note "pragma"; {
+    ok(utf8::is_utf8("癸"), "utf8 pragma is on");
+}
 
-ok(utf8::is_utf8("癸"), "utf8 pragma is on");
+note "io_layers"; {
+    is get_layers(*STDOUT), $Layers{STDOUT}, "STDOUT encoding is untouched";
+    is get_layers(*STDERR), $Layers{STDERR}, "STDERR encoding is untouched";
+}
 
-my $layers = { map {$_ => 1} PerlIO::get_layers(STDERR) };
-ok($layers->{utf8}, "utf8 is on for STDERR");
-
-$layers = { map {$_ => 1} PerlIO::get_layers(STDOUT) };
-ok($layers->{utf8}, "utf8 is on for STDOUT");
-
-my $format = Test2::API::test2_stack->top->format;
-my $handles = $format->handles;
-for my $hn (0 .. @$handles) {
-    my $h = $handles->[$hn] || next;
-    $layers = { map {$_ => 1} PerlIO::get_layers($h) };
-    ok($layers->{utf8}, "utf8 is on for formatter handle $hn");
+note "format_handles"; {
+    my $format = test2_stack()->top->format;
+    my $handles = $format->handles;
+    for my $hn (0 .. @$handles) {
+        my $h = $handles->[$hn] || next;
+        my $layers = get_layers($h);
+        ok($layers->{utf8}, "utf8 is on for formatter handle $hn");
+    }
 }
 
 done_testing;


### PR DESCRIPTION
Test libraries should avoid altering the global environment lest
code work in testing and not in production.

I also changed the docs to be less specific about what exactly this
module does to allow us flexibility to make small changes in the
future. If you say "this is the same as" someone is going to take
you literally.

This should not be merged until the discussion in #92 is resolved.
