### PR TITLE
remove __WARN__ hook before re-warning

### DIFF
--- a/lib/Test2/Util/Table.pm
+++ b/lib/Test2/Util/Table.pm
@@ -24,10 +24,12 @@ sub term_size {
     my $total;
     try {
         my @warnings;
-        local $SIG{__WARN__} = sub { push @warnings => @_ };
-        ($total) = Term::ReadKey::GetTerminalSize(*STDOUT);
+        {
+            local $SIG{__WARN__} = sub { push @warnings => @_ };
+            ($total) = Term::ReadKey::GetTerminalSize(*STDOUT);
+        }
         @warnings = grep { $_ !~ m/Unable to get Terminal Size/ } @warnings;
-        warn @warnings;
+        warn @warnings if @warnings;
     };
     return 80 if !$total;
     return 80 if $total < 80;


### PR DESCRIPTION
If the __WARN__ hook is still in place when we call warn, it will just<br />end up eating the warnings again.<br /><br />Additionally, this mix of warning an array that warn will modify<br />triggers fun bugs inside at least perl 5.8.8, breaking argument passing<br />in some odd cases.<br /><br />Fixes testers report a4a15e22-7e8c-11e6-9801-054b175f6707 and others.