### PR TITLE
Use the HashBase constants for _file and _line.

### DIFF
--- a/lib/Test2/Compare/Base.pm
+++ b/lib/Test2/Compare/Base.pm
@@ -30,8 +30,8 @@ sub clone {
 
 sub init {
     my $self = shift;
-    $self->{_lines} = delete $self->{lines} if exists $self->{lines};
-    $self->{_file}  = delete $self->{file}  if exists $self->{file};
+    $self->{+_LINES} = delete $self->{lines} if exists $self->{lines};
+    $self->{+_FILE}  = delete $self->{file}  if exists $self->{file};
 }
 
 sub file {


### PR DESCRIPTION
Something I noticed while poking around. This appears to be an oversight.

I checked for other cases with `ack '\$self->\{[^$+]'` and they all appear to be legit exceptions.