### PR TITLE
When adding an AUTOLOAD to a mocked object's class also add a can sub

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+    - Fix mocked objects so that they respond properly to ->can when using AUTOLOAD.
+
 0.000060  2016-09-25 12:38:43-07:00 America/Los_Angeles
 
     - Fix some docs

--- a/lib/Test2/Mock.pm
+++ b/lib/Test2/Mock.pm
@@ -155,13 +155,15 @@ sub autoload {
 
     croak "Class '$class' already has an AUTOLOAD"
         if $stash->{AUTOLOAD} && *{$stash->{AUTOLOAD}}{CODE};
+    croak "Class '$class' already has an can"
+        if $stash->{can} && *{$stash->{can}}{CODE};
 
     # Weaken this reference so that AUTOLOAD does not prevent its own
     # destruction.
     weaken(my $c = $self);
 
     my ($file, $line) = (__FILE__, __LINE__ + 3);
-    my $sub = eval <<EOT || die $@;
+    my $sub = eval <<EOT || die "Failed generating AUTOLOAD sub: $@";
 package $class;
 #line $line "$file (Generated AUTOLOAD)"
 our \$AUTOLOAD;
@@ -183,6 +185,24 @@ our \$AUTOLOAD;
 EOT
 
     $self->add(AUTOLOAD => $sub);
+
+    $line = __LINE__ + 3;
+    $sub = eval <<EOT || die "Failed generating can method: $@";
+package $class;
+#line $line "$file (Generated can)"
+    sub {
+        my (\$self, \$meth) = \@_;
+        if (\$self->SUPER::can(\$meth)) {
+            return \$self->SUPER::can(\$meth);
+        }
+        elsif (exists \$self->{\$meth}) {
+            return sub { shift->\$meth(\@_) };
+        }
+        return undef;
+    }
+EOT
+
+    $self->add(can => $sub);
 }
 
 sub before {

--- a/t/modules/Tools/Mock.t
+++ b/t/modules/Tools/Mock.t
@@ -143,8 +143,26 @@ subtest mock_obj => sub {
         add => [ bar => sub { 'bar' }],
     );
 
+    # We need to test the methods returned by ->can before we call the subs by
+    # name. This lets us be sure that this works _before_ the AUTOLOAD
+    # actually creates the named sub for real.
+    my $foo = $obj->can('foo');
+    $obj->$foo('foo2');
+    is($obj->$foo, 'foo2', "->can('foo') returns a method that works as a setter");
+    $obj->$foo('foo');
+
+    my $bar = $obj->can('bar');
+    is($obj->$bar, 'bar', "->can('bar') returns a method");
+    ok(!$obj->can('baz'), "mock object ->can returns false for baz");
+
     is($obj->foo, 'foo', "got value for foo");
     is($obj->bar, 'bar', "got value for bar");
+
+    ok($obj->can('foo'), "mock object ->can returns true for foo");
+    ok($obj->can('bar'), "mock object ->can returns true for bar");
+    ok($obj->can('isa'), "mock object ->can returns true for isa");
+
+    my $foo = $obj->can('foo');
 
     my ($c) = mocked($obj);
     ok($c, "got control");


### PR DESCRIPTION
Otherwise these objects return false for $obj->can('foo') even if $obj->foo
would work. This is obviously a huge problem when trying to use these mock
objects with anything doing duck type checks.