### PR TITLE
Handle an event without a trace object in Test2::Compare::Event

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+    - An event without a trace object would an exception when using
+      Test2::Compare::Event and the comparison failed
+
 0.000061  2016-11-26 12:39:14-08:00 America/Los_Angeles
 
     - Fix mocked objects so that they respond properly to ->can when using AUTOLOAD.

--- a/lib/Test2/Compare/Event.pm
+++ b/lib/Test2/Compare/Event.pm
@@ -27,6 +27,7 @@ sub got_lines {
     return unless $event;
     return unless blessed($event);
     return unless $event->isa('Test2::Event');
+    return unless $event->trace;
 
     return ($event->trace->line);
 }


### PR DESCRIPTION
Without this check we can blow up when given an event without a trace, and
there's nothing in the core event code that _forces_ a trace to exist.