### PR TITLE
Allow to declare plan in `done_testing`

### DIFF
--- a/lib/Test2/Tools/Basic.pm
+++ b/lib/Test2/Tools/Basic.pm
@@ -102,6 +102,9 @@ sub skip_all {
 
 sub done_testing {
     my $ctx = context();
+
+    $ctx->plan(shift) if @_;
+
     $ctx->hub->finalize($ctx->trace, 1);
     $ctx->release;
 }


### PR DESCRIPTION
For #96 

I'm not too sure how the testsuite works, so I didn't add any test. But trying test files like

```
use Test2::Bundle::Extended;

pass $_ for 1..3;

done_testing(4);
```

seems to indicate the minimalistic patch works.