### PR TITLE
Class tests failed if the class overloads the bool operator

### DIFF
--- a/lib/Test2/Compare.pm
+++ b/lib/Test2/Compare.pm
@@ -118,7 +118,7 @@ sub _convert {
     return Test2::Compare::Undef->new()
         unless defined $thing;
 
-    if ($thing && blessed($thing) && $thing->isa('Test2::Compare::Base')) {
+    if (blessed($thing) && $thing->isa('Test2::Compare::Base')) {
         if ($config->{implicit_end} && $thing->can('set_ending') && !defined $thing->ending) {
             my $clone = $thing->clone;
             $clone->set_ending('implicit');

--- a/lib/Test2/Compare/Array.pm
+++ b/lib/Test2/Compare/Array.pm
@@ -47,7 +47,8 @@ sub verify {
     my %params = @_;
 
     return 0 unless $params{exists};
-    my $got = $params{got} || return 0;
+    my $got = $params{got};
+    return 0 unless defined $got;
     return 0 unless ref($got);
     return 0 unless reftype($got) eq 'ARRAY';
     return 1;

--- a/lib/Test2/Compare/Base.pm
+++ b/lib/Test2/Compare/Base.pm
@@ -94,7 +94,7 @@ sub run {
     my $got = $exists ? $params{got} : undef;
 
     # Prevent infinite cycles
-    if ($got && ref $got) {
+    if (defined($got) && ref $got) {
         die "Cycle detected in comparison, aborting"
             if $seen->{$got} && $seen->{$got} >= MAX_CYCLES;
         $seen->{$got}++;
@@ -103,7 +103,7 @@ sub run {
     my $ok = $self->verify(%params);
     my @deltas = $ok ? $self->deltas(%params) : ();
 
-    $seen->{$got}-- if $got && ref $got;
+    $seen->{$got}-- if defined $got && ref $got;
 
     return if $ok && !@deltas;
 

--- a/lib/Test2/Compare/Hash.pm
+++ b/lib/Test2/Compare/Hash.pm
@@ -48,8 +48,8 @@ sub verify {
     my %params = @_;
     my ($got, $exists) = @params{qw/got exists/};
 
-    return 0 unless $exists;
-    return 0 unless $got;
+    return 0 unless defined $exists;
+    return 0 unless defined $got;
     return 0 unless ref($got);
     return 0 unless reftype($got) eq 'HASH';
     return 1;

--- a/lib/Test2/Compare/Object.pm
+++ b/lib/Test2/Compare/Object.pm
@@ -10,6 +10,9 @@ use base 'Test2::Compare::Base';
 
 our $VERSION = '0.000068';
 
+use overload bool => sub { 0 };
+use overload bool => sub { $_[0] };
+
 use Test2::Util::HashBase qw/calls meta refcheck ending/;
 
 use Carp qw/croak confess/;
@@ -32,7 +35,7 @@ sub verify {
     my ($got, $exists) = @params{qw/got exists/};
 
     return 0 unless $exists;
-    return 0 unless $got;
+    return 0 unless defined $got;
     return 0 unless ref($got);
     return 0 unless blessed($got);
     return 0 unless $got->isa($self->object_base);

--- a/lib/Test2/Tools/Class.pm
+++ b/lib/Test2/Tools/Class.pm
@@ -38,7 +38,7 @@ BEGIN {
 
             $name ||= @items == 1 ? "$thing_name\->$op('$items[0]')" : "$thing_name\->$op(...)";
 
-            unless ($thing && (blessed($thing) || !ref($thing))) {
+            unless ( defined $thing && (blessed($thing) || ( !ref($thing) && $thing ) ) ) {
                 my $thing = defined($thing)
                     ? ref($thing) || "'$thing'"
                     : '<undef>';

--- a/t/modules/Compare/Object.t
+++ b/t/modules/Compare/Object.t
@@ -12,7 +12,7 @@ subtest simple => sub {
 
     is($one->object_base, 'UNIVERSAL', "Correct object base");
 
-    ok($CLASS->new(calls => []), "Can specify a calls array")
+    ok(defined $CLASS->new(calls => []), "Can specify a calls array")
 };
 
 subtest verify => sub {
@@ -106,6 +106,9 @@ subtest add_call => sub {
 {
     package Foo::Bar;
 
+    use overload bool => sub { 0 };
+    use overload '""' => sub { $_[0] };
+
     sub foo { 'foo' }
     sub baz { 'baz' }
     sub one { 1 }
@@ -113,6 +116,9 @@ subtest add_call => sub {
     sub args { shift; +{@_} }
 
     package Fake::Fake;
+
+    use overload bool => sub { 0 };
+    use overload '""' => sub { $_[0] };
 
     sub foo { 'xxx' }
     sub one { 2 }

--- a/t/modules/Tools/Class.t
+++ b/t/modules/Tools/Class.t
@@ -38,7 +38,7 @@ use Test2::Bundle::Extended -target => 'Test2::Tools::Class';
 {
     package My::String;
     use overload '""' => sub { "xxx\nyyy" };
-
+    use overload 'bool' => sub { 0 } ;
     sub DOES { 0 }
 }
 


### PR DESCRIPTION
The check to see if $thing was not a blessed reference or package name:

  unless ($thing && (blessed($thing) || !ref($thing)))

fails in the context where $thing might be an object with an
overloaded bool operator.  The above code is more accurately written
as the pseudo-code

  unless (bool($thing) && (blessed($thing) || !ref($thing))),

what is really required is:

     unless (  ( is object ) || (  ! is object && ! empty string ) )

which turns into

      unless ( ( defined $thing && blessed($thing) )
               ||
               ( defined $thng && !ref($thing) && $thing )
	       )
      )

or more succinctly,

      unless ( defined $thing && (blessed($thing) || ( !ref($thing) && $thing ) ) )