### PR TITLE
Another round of bool overload fixes

### DIFF
--- a/lib/Test2/Compare/Array.pm
+++ b/lib/Test2/Compare/Array.pm
@@ -14,7 +14,7 @@ use Scalar::Util qw/reftype looks_like_number/;
 sub init {
     my $self = shift;
 
-    if(my $ref = $self->{+INREF}) {
+    if( defined( my $ref = $self->{+INREF}) ) {
         croak "Cannot specify both 'inref' and 'items'" if $self->{+ITEMS};
         croak "Cannot specify both 'inref' and 'order'" if $self->{+ORDER};
         croak "'inref' must be an array reference, got '$ref'" unless reftype($ref) eq 'ARRAY';

--- a/lib/Test2/Compare/Base.pm
+++ b/lib/Test2/Compare/Base.pm
@@ -10,6 +10,9 @@ use Scalar::Util qw/blessed/;
 use Sub::Info qw/sub_info/;
 use Test2::Compare::Delta();
 
+use overload bool => sub { 0 };
+use overload '""' => sub { $_[0] };
+
 sub MAX_CYCLES() { 75 }
 
 use Test2::Util::HashBase qw{builder _file _lines _info called};

--- a/lib/Test2/Compare/Delta.pm
+++ b/lib/Test2/Compare/Delta.pm
@@ -113,7 +113,7 @@ sub render_got {
     return '<UNDEF>' unless defined $got;
 
     my $check = $self->{+CHK};
-    my $stringify = $check && $check->stringify_got;
+    my $stringify = defined( $check ) && $check->stringify_got;
 
     return render_ref($got) if ref $got && !$stringify;
 
@@ -176,7 +176,7 @@ sub _join_id {
 sub should_show {
     my $self = shift;
     return 1 unless $self->verified;
-    my $check = $self->check || return 0;
+    defined( my $check = $self->check ) || return 0;
     return 0 unless $check->lines;
     my $file = $check->file || return 0;
 
@@ -218,7 +218,7 @@ sub table_header { [map {$COLUMNS{$_}->{alias} || $_} @COLUMN_ORDER] }
 sub table_op {
     my $self = shift;
 
-    my $check = $self->{+CHK} || return '!exists';
+    defined( my $check = $self->{+CHK} ) || return '!exists';
 
     return $check->operator($self->{+GOT})
         unless $self->{+DNE} && $self->{+DNE} eq 'got';
@@ -229,7 +229,7 @@ sub table_op {
 sub table_check_lines {
     my $self = shift;
 
-    my $check = $self->{+CHK} || return '';
+    defined( my $check = $self->{+CHK} ) || return '';
     my $lines = $check->lines || return '';
 
     return '' unless @$lines;
@@ -240,7 +240,7 @@ sub table_check_lines {
 sub table_got_lines {
     my $self = shift;
 
-    my $check = $self->{+CHK} || return '';
+    defined( my $check = $self->{+CHK} ) || return '';
     return '' if $self->{+DNE} && $self->{+DNE} eq 'got';
 
     my @lines = $check->got_lines($self->{+GOT});

--- a/lib/Test2/Compare/Hash.pm
+++ b/lib/Test2/Compare/Hash.pm
@@ -14,7 +14,7 @@ use Scalar::Util qw/reftype/;
 sub init {
     my $self = shift;
 
-    if(my $ref = $self->{+INREF}) {
+    if( defined( my $ref = $self->{+INREF} ) ) {
         croak "Cannot specify both 'inref' and 'items'" if $self->{+ITEMS};
         croak "Cannot specify both 'inref' and 'order'" if $self->{+ORDER};
         $self->{+ITEMS} = {%$ref};

--- a/lib/Test2/Compare/Object.pm
+++ b/lib/Test2/Compare/Object.pm
@@ -10,9 +10,6 @@ use base 'Test2::Compare::Base';
 
 our $VERSION = '0.000068';
 
-use overload bool => sub { 0 };
-use overload '""' => sub { $_[0] };
-
 use Test2::Util::HashBase qw/calls meta refcheck ending/;
 
 use Carp qw/croak confess/;

--- a/lib/Test2/Compare/Object.pm
+++ b/lib/Test2/Compare/Object.pm
@@ -41,13 +41,13 @@ sub verify {
 
 sub add_prop {
     my $self = shift;
-    $self->{+META} ||= $self->meta_class->new;
+    $self->{+META} = $self->meta_class->new unless defined $self->{+META};
     $self->{+META}->add_prop(@_);
 }
 
 sub add_field {
     my $self = shift;
-    $self->{+REFCHECK} ||= Test2::Compare::Hash->new;
+    $self->{+REFCHECK} = Test2::Compare::Hash->new unless defined $self->{+REFCHECK};
 
     croak "Underlying reference does not have fields"
         unless $self->{+REFCHECK}->can('add_field');
@@ -57,7 +57,7 @@ sub add_field {
 
 sub add_item {
     my $self = shift;
-    $self->{+REFCHECK} ||= Test2::Compare::Array->new;
+    $self->{+REFCHECK} = Test2::Compare::Array->new unless defined $self->{+REFCHECK};
 
     croak "Underlying reference does not have items"
         unless $self->{+REFCHECK}->can('add_item');
@@ -83,7 +83,7 @@ sub deltas {
     my $meta     = $self->{+META};
     my $refcheck = $self->{+REFCHECK};
 
-    push @deltas => $meta->deltas(%params) if $meta;
+    push @deltas => $meta->deltas(%params) if defined $meta;
 
     for my $call (@{$self->{+CALLS}}) {
         my ($meth, $check, $name, $context)= @$call;
@@ -127,7 +127,7 @@ sub deltas {
         }
     }
 
-    return @deltas unless $refcheck;
+    return @deltas unless defined $refcheck;
 
     $refcheck->set_ending($self->{+ENDING});
 

--- a/lib/Test2/Compare/OrderedSubset.pm
+++ b/lib/Test2/Compare/OrderedSubset.pm
@@ -32,7 +32,7 @@ sub verify {
     my %params = @_;
 
     return 0 unless $params{exists};
-    my $got = $params{got} || return 0;
+    defined( my $got = $params{got} ) || return 0;
     return 0 unless ref($got);
     return 0 unless reftype($got) eq 'ARRAY';
     return 1;

--- a/lib/Test2/Compare/Scalar.pm
+++ b/lib/Test2/Compare/Scalar.pm
@@ -14,7 +14,7 @@ use Scalar::Util qw/reftype blessed/;
 sub init {
     my $self = shift;
     croak "'item' is a required attribute"
-        unless $self->{+ITEM};
+        unless defined $self->{+ITEM};
 
     $self->SUPER::init();
 }

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -200,7 +200,7 @@ sub D() {
 sub DF() {
     my @caller = caller;
     Test2::Compare::Custom->new(
-        code => sub { defined $_ && ! $_ ? 1 : 0 }, name => 'DEFINED BUT FALSE', operator => 'DEFINED() && FALSE()',
+        code => sub { defined $_ && ( ! ref $_ && ! $_ ) ? 1 : 0 }, name => 'DEFINED BUT FALSE', operator => 'DEFINED() && FALSE()',
         file => $caller[1],
         lines => [$caller[2]],
     );
@@ -236,7 +236,7 @@ sub F() {
 sub FDNE() {
     my @caller = caller;
     Test2::Compare::Custom->new(
-        code => sub { $_ ? 0 : 1 }, name => 'FALSE', operator => 'FALSE() || !exists',
+        code => sub { defined $_ && ( ref $_ || $_ ) ? 0 : 1 }, name => 'FALSE', operator => 'FALSE() || !exists',
         file => $caller[1],
         lines => [$caller[2]],
     );
@@ -245,7 +245,7 @@ sub FDNE() {
 sub T() {
     my @caller = caller;
     Test2::Compare::Custom->new(
-        code => sub { $_ ? 1 : 0 }, name => 'TRUE', operator => 'TRUE()',
+        code => sub { defined $_ && ( ref $_ || $_ ) ? 1 : 0 }, name => 'TRUE', operator => 'TRUE()',
         file => $caller[1],
         lines => [$caller[2]],
     );

--- a/t/modules/Compare.t
+++ b/t/modules/Compare.t
@@ -6,7 +6,7 @@ use warnings;
 # extended bundle)
 BEGIN {
     require Test2::Compare;
-    def ok => (Test2::Compare::convert(undef), "convert returned something to us");
+    def ok => (defined Test2::Compare::convert(undef), "convert returned something to us");
     def ok => ($INC{'Test2/Compare/Undef.pm'}, "loaded the Test2::Compare::Undef module");
 }
 

--- a/t/modules/Compare/Array.t
+++ b/t/modules/Compare/Array.t
@@ -231,4 +231,24 @@ subtest deltas => sub {
     );
 };
 
+{
+  package Foo;
+
+  use overload bool => sub { 0 };
+  use overload '""' => sub { $_[0] };
+  sub new {
+      my $class = shift;
+      bless [ @_ ] , $class;
+  }
+}
+
+subtest objects_as_arrays => sub {
+
+    my $o1 = Foo->new( 'b' ) ;
+    my $o2 = Foo->new( 'b' ) ;
+
+    is ( $o1, $o2, "same" );
+};
+
+
 done_testing;

--- a/t/modules/Compare/Hash.t
+++ b/t/modules/Compare/Hash.t
@@ -178,4 +178,24 @@ subtest deltas => sub {
 
 };
 
+{
+  package Foo;
+
+  use overload bool => sub { 0 };
+  use overload '""' => sub { $_[0] };
+  sub new {
+      my $class = shift;
+      bless { @_ } , $class;
+  }
+}
+
+subtest objects_with_hashes => sub {
+
+    my $o1 = Foo->new( b => { foo => 2 } ) ;
+    my $o2 = Foo->new( b => { foo => 2 } ) ;
+
+    is ( $o1, $o2, "same" );
+};
+
+
 done_testing;

--- a/t/modules/Compare/Hash.t
+++ b/t/modules/Compare/Hash.t
@@ -20,7 +20,7 @@ subtest verify => sub {
 
 subtest init => sub {
     my $one = $CLASS->new();
-    ok($one, "args are not required");
+    ok( defined $one, "args are not required");
     is($one->items, {}, "got the items hash");
     is($one->order, [], "got order array");
 

--- a/t/modules/Compare/Meta.t
+++ b/t/modules/Compare/Meta.t
@@ -9,7 +9,7 @@ subtest simple => sub {
     is($one->name, '<META CHECKS>', "sane name");
     is($one->verify(exists => 0), 0, "Does not verify for non-existant values");
     is($one->verify(exists => 1), 1, "always verifies for existing values");
-    ok($CLASS->new(items => []), "Can provide items");
+    ok(defined $CLASS->new(items => []), "Can provide items");
 };
 
 subtest add_prop => sub {

--- a/t/modules/Compare/OrderedSubset.t
+++ b/t/modules/Compare/OrderedSubset.t
@@ -93,4 +93,22 @@ subtest deltas => sub {
     );
 };
 
+{
+  package Foo;
+
+  use overload bool => sub { 0 };
+  use overload '""' => sub { $_[0] };
+  sub new {
+      my $class = shift;
+      bless [ @_ ] , $class;
+  }
+}
+
+subtest object_as_arrays => sub {
+
+    my $o1 = Foo->new( 'b') ;
+
+    is ( $o1 , subset{  item 'b' }, "same" );
+};
+
 done_testing;

--- a/t/modules/Compare/Wildcard.t
+++ b/t/modules/Compare/Wildcard.t
@@ -3,9 +3,9 @@ use Test2::Bundle::Extended -target => 'Test2::Compare::Wildcard';
 my $one = $CLASS->new(expect => 'foo');
 isa_ok($one, $CLASS, 'Test2::Compare::Base');
 
-ok($CLASS->new(expect => 0), "0 is a valid expect value");
-ok($CLASS->new(expect => undef), "undef is a valid expect value");
-ok($CLASS->new(expect => ''), "'' is a valid expect value");
+ok(defined $CLASS->new(expect => 0), "0 is a valid expect value");
+ok(defined $CLASS->new(expect => undef), "undef is a valid expect value");
+ok(defined $CLASS->new(expect => ''), "'' is a valid expect value");
 
 like(
     dies { $CLASS->new() },


### PR DESCRIPTION
I realized that the Compare::* Classes subclassed Compare::Base, so I moved the bool overload there to trigger more boolean contexts.  This PR fixes those as well as a couple of corner cases.

There may be more PR's coming, as I'm still tracking down an errant test result (which may be in my code rather than Test2::Suite).