### PR TITLE
 Bool overload fix, second attempt

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+    - Ensure that objects are not used in Boolean contexts, second
+      attempt. (djerius)
+
 0.000074  2017-08-31 20:37:47-07:00 America/Los_Angeles (TRIAL RELEASE)
 
     - Add Test2::Event::Times

--- a/lib/Test2/Compare.pm
+++ b/lib/Test2/Compare.pm
@@ -118,7 +118,7 @@ sub _convert {
     return Test2::Compare::Undef->new()
         unless defined $thing;
 
-    if ($thing && blessed($thing) && $thing->isa('Test2::Compare::Base')) {
+    if (blessed($thing) && $thing->isa('Test2::Compare::Base')) {
         if ($config->{implicit_end} && $thing->can('set_ending') && !defined $thing->ending) {
             my $clone = $thing->clone;
             $clone->set_ending('implicit');

--- a/lib/Test2/Compare/Array.pm
+++ b/lib/Test2/Compare/Array.pm
@@ -14,7 +14,7 @@ use Scalar::Util qw/reftype looks_like_number/;
 sub init {
     my $self = shift;
 
-    if(my $ref = $self->{+INREF}) {
+    if( defined( my $ref = $self->{+INREF}) ) {
         croak "Cannot specify both 'inref' and 'items'" if $self->{+ITEMS};
         croak "Cannot specify both 'inref' and 'order'" if $self->{+ORDER};
         croak "'inref' must be an array reference, got '$ref'" unless reftype($ref) eq 'ARRAY';
@@ -47,7 +47,8 @@ sub verify {
     my %params = @_;
 
     return 0 unless $params{exists};
-    my $got = $params{got} || return 0;
+    my $got = $params{got};
+    return 0 unless defined $got;
     return 0 unless ref($got);
     return 0 unless reftype($got) eq 'ARRAY';
     return 1;

--- a/lib/Test2/Compare/Base.pm
+++ b/lib/Test2/Compare/Base.pm
@@ -94,7 +94,7 @@ sub run {
     my $got = $exists ? $params{got} : undef;
 
     # Prevent infinite cycles
-    if ($got && ref $got) {
+    if (defined($got) && ref $got) {
         die "Cycle detected in comparison, aborting"
             if $seen->{$got} && $seen->{$got} >= MAX_CYCLES;
         $seen->{$got}++;
@@ -103,7 +103,7 @@ sub run {
     my $ok = $self->verify(%params);
     my @deltas = $ok ? $self->deltas(%params) : ();
 
-    $seen->{$got}-- if $got && ref $got;
+    $seen->{$got}-- if defined $got && ref $got;
 
     return if $ok && !@deltas;
 

--- a/lib/Test2/Compare/Delta.pm
+++ b/lib/Test2/Compare/Delta.pm
@@ -113,7 +113,7 @@ sub render_got {
     return '<UNDEF>' unless defined $got;
 
     my $check = $self->{+CHK};
-    my $stringify = $check && $check->stringify_got;
+    my $stringify = defined( $check ) && $check->stringify_got;
 
     return render_ref($got) if ref $got && !$stringify;
 
@@ -176,7 +176,7 @@ sub _join_id {
 sub should_show {
     my $self = shift;
     return 1 unless $self->verified;
-    my $check = $self->check || return 0;
+    defined( my $check = $self->check ) || return 0;
     return 0 unless $check->lines;
     my $file = $check->file || return 0;
 
@@ -218,7 +218,7 @@ sub table_header { [map {$COLUMNS{$_}->{alias} || $_} @COLUMN_ORDER] }
 sub table_op {
     my $self = shift;
 
-    my $check = $self->{+CHK} || return '!exists';
+    defined( my $check = $self->{+CHK} ) || return '!exists';
 
     return $check->operator($self->{+GOT})
         unless $self->{+DNE} && $self->{+DNE} eq 'got';
@@ -229,7 +229,7 @@ sub table_op {
 sub table_check_lines {
     my $self = shift;
 
-    my $check = $self->{+CHK} || return '';
+    defined( my $check = $self->{+CHK} ) || return '';
     my $lines = $check->lines || return '';
 
     return '' unless @$lines;
@@ -240,7 +240,7 @@ sub table_check_lines {
 sub table_got_lines {
     my $self = shift;
 
-    my $check = $self->{+CHK} || return '';
+    defined( my $check = $self->{+CHK} ) || return '';
     return '' if $self->{+DNE} && $self->{+DNE} eq 'got';
 
     my @lines = $check->got_lines($self->{+GOT});

--- a/lib/Test2/Compare/Hash.pm
+++ b/lib/Test2/Compare/Hash.pm
@@ -14,7 +14,7 @@ use Scalar::Util qw/reftype/;
 sub init {
     my $self = shift;
 
-    if(my $ref = $self->{+INREF}) {
+    if( defined( my $ref = $self->{+INREF} ) ) {
         croak "Cannot specify both 'inref' and 'items'" if $self->{+ITEMS};
         croak "Cannot specify both 'inref' and 'order'" if $self->{+ORDER};
         $self->{+ITEMS} = {%$ref};
@@ -49,7 +49,7 @@ sub verify {
     my ($got, $exists) = @params{qw/got exists/};
 
     return 0 unless $exists;
-    return 0 unless $got;
+    return 0 unless defined $got;
     return 0 unless ref($got);
     return 0 unless reftype($got) eq 'HASH';
     return 1;

--- a/lib/Test2/Compare/Object.pm
+++ b/lib/Test2/Compare/Object.pm
@@ -32,7 +32,7 @@ sub verify {
     my ($got, $exists) = @params{qw/got exists/};
 
     return 0 unless $exists;
-    return 0 unless $got;
+    return 0 unless defined $got;
     return 0 unless ref($got);
     return 0 unless blessed($got);
     return 0 unless $got->isa($self->object_base);
@@ -41,13 +41,13 @@ sub verify {
 
 sub add_prop {
     my $self = shift;
-    $self->{+META} ||= $self->meta_class->new;
+    $self->{+META} = $self->meta_class->new unless defined $self->{+META};
     $self->{+META}->add_prop(@_);
 }
 
 sub add_field {
     my $self = shift;
-    $self->{+REFCHECK} ||= Test2::Compare::Hash->new;
+    $self->{+REFCHECK} = Test2::Compare::Hash->new unless defined $self->{+REFCHECK};
 
     croak "Underlying reference does not have fields"
         unless $self->{+REFCHECK}->can('add_field');
@@ -57,7 +57,7 @@ sub add_field {
 
 sub add_item {
     my $self = shift;
-    $self->{+REFCHECK} ||= Test2::Compare::Array->new;
+    $self->{+REFCHECK} = Test2::Compare::Array->new unless defined $self->{+REFCHECK};
 
     croak "Underlying reference does not have items"
         unless $self->{+REFCHECK}->can('add_item');
@@ -83,7 +83,7 @@ sub deltas {
     my $meta     = $self->{+META};
     my $refcheck = $self->{+REFCHECK};
 
-    push @deltas => $meta->deltas(%params) if $meta;
+    push @deltas => $meta->deltas(%params) if defined $meta;
 
     for my $call (@{$self->{+CALLS}}) {
         my ($meth, $check, $name, $context)= @$call;
@@ -127,7 +127,7 @@ sub deltas {
         }
     }
 
-    return @deltas unless $refcheck;
+    return @deltas unless defined $refcheck;
 
     $refcheck->set_ending($self->{+ENDING});
 

--- a/lib/Test2/Compare/OrderedSubset.pm
+++ b/lib/Test2/Compare/OrderedSubset.pm
@@ -32,7 +32,7 @@ sub verify {
     my %params = @_;
 
     return 0 unless $params{exists};
-    my $got = $params{got} || return 0;
+    defined( my $got = $params{got} ) || return 0;
     return 0 unless ref($got);
     return 0 unless reftype($got) eq 'ARRAY';
     return 1;

--- a/lib/Test2/Compare/Scalar.pm
+++ b/lib/Test2/Compare/Scalar.pm
@@ -14,7 +14,7 @@ use Scalar::Util qw/reftype blessed/;
 sub init {
     my $self = shift;
     croak "'item' is a required attribute"
-        unless $self->{+ITEM};
+        unless defined $self->{+ITEM};
 
     $self->SUPER::init();
 }

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -200,7 +200,7 @@ sub D() {
 sub DF() {
     my @caller = caller;
     Test2::Compare::Custom->new(
-        code => sub { defined $_ && ! $_ ? 1 : 0 }, name => 'DEFINED BUT FALSE', operator => 'DEFINED() && FALSE()',
+        code => sub { defined $_ && ( ! ref $_ && ! $_ ) ? 1 : 0 }, name => 'DEFINED BUT FALSE', operator => 'DEFINED() && FALSE()',
         file => $caller[1],
         lines => [$caller[2]],
     );
@@ -236,7 +236,7 @@ sub F() {
 sub FDNE() {
     my @caller = caller;
     Test2::Compare::Custom->new(
-        code => sub { $_ ? 0 : 1 }, name => 'FALSE', operator => 'FALSE() || !exists',
+        code => sub { defined $_ && ( ref $_ || $_ ) ? 0 : 1 }, name => 'FALSE', operator => 'FALSE() || !exists',
         file => $caller[1],
         lines => [$caller[2]],
     );
@@ -245,7 +245,7 @@ sub FDNE() {
 sub T() {
     my @caller = caller;
     Test2::Compare::Custom->new(
-        code => sub { $_ ? 1 : 0 }, name => 'TRUE', operator => 'TRUE()',
+        code => sub { defined $_ && ( ref $_ || $_ ) ? 1 : 0 }, name => 'TRUE', operator => 'TRUE()',
         file => $caller[1],
         lines => [$caller[2]],
     );
@@ -328,7 +328,7 @@ sub string($;@) {
 }
 
 sub filter_items(&) {
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' does not support filters"
         unless $build->can('add_filter');
@@ -340,7 +340,7 @@ sub filter_items(&) {
 }
 
 sub all_items {
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' does not support all-items"
         unless $build->can('add_for_each');
@@ -352,7 +352,7 @@ sub all_items {
 }
 
 sub all_keys {
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' does not support all-keys"
         unless $build->can('add_for_each_key');
@@ -365,7 +365,7 @@ sub all_keys {
 
 *all_vals = *all_values;
 sub all_values {
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' does not support all-values"
         unless $build->can('add_for_each_val');
@@ -378,7 +378,7 @@ sub all_values {
 
 
 sub end() {
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' does not support 'ending'"
         unless $build->can('ending');
@@ -390,7 +390,7 @@ sub end() {
 }
 
 sub etc() {
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' does not support 'ending'"
         unless $build->can('ending');
@@ -403,7 +403,7 @@ sub etc() {
 
 my $_call = sub {
     my ($name, $expect, $context, $func_name) = @_;
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' does not support method calls"
         unless $build->can('add_call');
@@ -430,7 +430,7 @@ sub call_hash($$) { $_call->(@_,'hash','call_hash') }
 
 sub prop($$) {
     my ($name, $expect) = @_;
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' does not support meta-checks"
         unless $build->can('add_prop');
@@ -453,7 +453,7 @@ sub item($;$) {
     my @args   = @_;
     my $expect = pop @args;
 
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' does not support array item checks"
         unless $build->can('add_item');
@@ -474,7 +474,7 @@ sub item($;$) {
 sub field($$) {
     my ($name, $expect) = @_;
 
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' does not support hash field checks"
         unless $build->can('add_field');
@@ -496,7 +496,7 @@ sub field($$) {
 sub check($) {
     my ($check) = @_;
 
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
 
     croak "'$build' is not a check-set"
         unless $build->can('add_check');
@@ -543,7 +543,7 @@ sub fail_events($;$) {
 
     return ($event, $diag) if defined wantarray;
 
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
     $build->add_item($event);
     $build->add_item($diag);
 }
@@ -600,7 +600,7 @@ sub event($;$) {
 
     return $event if defined wantarray;
 
-    my $build = get_build() or croak "No current build!";
+    defined( my $build = get_build() ) or croak "No current build!";
     $build->add_item($event);
 }
 

--- a/t/lib/MyTest/Target.pm
+++ b/t/lib/MyTest/Target.pm
@@ -1,0 +1,8 @@
+package MyTest::Target;
+
+use Test2::Tools::Basic qw( fail );
+
+use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+use overload '""' => sub { $_[0] };
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Array.pm
+++ b/t/lib/MyTest/Test2/Compare/Array.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Array;
+
+use base 'Test2::Compare::Array';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Bag.pm
+++ b/t/lib/MyTest/Test2/Compare/Bag.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Bag;
+
+use base 'Test2::Compare::Bag';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Base.pm
+++ b/t/lib/MyTest/Test2/Compare/Base.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Base;
+
+use base 'Test2::Compare::Base';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Bool.pm
+++ b/t/lib/MyTest/Test2/Compare/Bool.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Bool;
+
+use base 'Test2::Compare::Bool';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Custom.pm
+++ b/t/lib/MyTest/Test2/Compare/Custom.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Custom;
+
+use base 'Test2::Compare::Custom';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Delta.pm
+++ b/t/lib/MyTest/Test2/Compare/Delta.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Delta;
+
+use base 'Test2::Compare::Delta';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Event.pm
+++ b/t/lib/MyTest/Test2/Compare/Event.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Event;
+
+use base 'Test2::Compare::Event';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/EventMeta.pm
+++ b/t/lib/MyTest/Test2/Compare/EventMeta.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::EventMeta;
+
+use base 'Test2::Compare::EventMeta';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Hash.pm
+++ b/t/lib/MyTest/Test2/Compare/Hash.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Hash;
+
+use base 'Test2::Compare::Hash';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Meta.pm
+++ b/t/lib/MyTest/Test2/Compare/Meta.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Meta;
+
+use base 'Test2::Compare::Meta';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Number.pm
+++ b/t/lib/MyTest/Test2/Compare/Number.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Number;
+
+use base 'Test2::Compare::Number';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Object.pm
+++ b/t/lib/MyTest/Test2/Compare/Object.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Object;
+
+use base 'Test2::Compare::Object';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/OrderedSubset.pm
+++ b/t/lib/MyTest/Test2/Compare/OrderedSubset.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::OrderedSubset;
+
+use base 'Test2::Compare::OrderedSubset';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Pattern.pm
+++ b/t/lib/MyTest/Test2/Compare/Pattern.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Pattern;
+
+use base 'Test2::Compare::Pattern';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Ref.pm
+++ b/t/lib/MyTest/Test2/Compare/Ref.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Ref;
+
+use base 'Test2::Compare::Ref';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Regex.pm
+++ b/t/lib/MyTest/Test2/Compare/Regex.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Regex;
+
+use base 'Test2::Compare::Regex';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Scalar.pm
+++ b/t/lib/MyTest/Test2/Compare/Scalar.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Scalar;
+
+use base 'Test2::Compare::Scalar';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Set.pm
+++ b/t/lib/MyTest/Test2/Compare/Set.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Set;
+
+use base 'Test2::Compare::Set';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/String.pm
+++ b/t/lib/MyTest/Test2/Compare/String.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::String;
+
+use base 'Test2::Compare::String';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Undef.pm
+++ b/t/lib/MyTest/Test2/Compare/Undef.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Undef;
+
+use base 'Test2::Compare::Undef';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Compare/Wildcard.pm
+++ b/t/lib/MyTest/Test2/Compare/Wildcard.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Compare::Wildcard;
+
+use base 'Test2::Compare::Wildcard';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Mock.pm
+++ b/t/lib/MyTest/Test2/Mock.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Mock;
+
+use base 'Test2::Mock';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Require/AuthorTesting.pm
+++ b/t/lib/MyTest/Test2/Require/AuthorTesting.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Require::AuthorTesting;
+
+use base 'Test2::Require::AuthorTesting';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Require/EnvVar.pm
+++ b/t/lib/MyTest/Test2/Require/EnvVar.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Require::EnvVar;
+
+use base 'Test2::Require::EnvVar';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Require/Fork.pm
+++ b/t/lib/MyTest/Test2/Require/Fork.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Require::Fork;
+
+use base 'Test2::Require::Fork';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Require/Module.pm
+++ b/t/lib/MyTest/Test2/Require/Module.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Require::Module;
+
+use base 'Test2::Require::Module';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Require/Perl.pm
+++ b/t/lib/MyTest/Test2/Require/Perl.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Require::Perl;
+
+use base 'Test2::Require::Perl';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Require/RealFork.pm
+++ b/t/lib/MyTest/Test2/Require/RealFork.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Require::RealFork;
+
+use base 'Test2::Require::RealFork';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Require/Threads.pm
+++ b/t/lib/MyTest/Test2/Require/Threads.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Require::Threads;
+
+use base 'Test2::Require::Threads';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Todo.pm
+++ b/t/lib/MyTest/Test2/Todo.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Todo;
+
+use base 'Test2::Todo';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/Basic.pm
+++ b/t/lib/MyTest/Test2/Tools/Basic.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::Basic;
+
+use base 'Test2::Tools::Basic';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/Class.pm
+++ b/t/lib/MyTest/Test2/Tools/Class.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::Class;
+
+use base 'Test2::Tools::Class';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/ClassicCompare.pm
+++ b/t/lib/MyTest/Test2/Tools/ClassicCompare.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::ClassicCompare;
+
+use base 'Test2::Tools::ClassicCompare';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/Compare.pm
+++ b/t/lib/MyTest/Test2/Tools/Compare.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::Compare;
+
+use base 'Test2::Tools::Compare';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/Defer.pm
+++ b/t/lib/MyTest/Test2/Tools/Defer.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::Defer;
+
+use base 'Test2::Tools::Defer';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/Encoding.pm
+++ b/t/lib/MyTest/Test2/Tools/Encoding.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::Encoding;
+
+use base 'Test2::Tools::Encoding';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/Exception.pm
+++ b/t/lib/MyTest/Test2/Tools/Exception.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::Exception;
+
+use base 'Test2::Tools::Exception';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/Exports.pm
+++ b/t/lib/MyTest/Test2/Tools/Exports.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::Exports;
+
+use base 'Test2::Tools::Exports';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/Ref.pm
+++ b/t/lib/MyTest/Test2/Tools/Ref.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::Ref;
+
+use base 'Test2::Tools::Ref';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/Subtest.pm
+++ b/t/lib/MyTest/Test2/Tools/Subtest.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::Subtest;
+
+use base 'Test2::Tools::Subtest';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Tools/Warnings.pm
+++ b/t/lib/MyTest/Test2/Tools/Warnings.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Tools::Warnings;
+
+use base 'Test2::Tools::Warnings';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Util/Grabber.pm
+++ b/t/lib/MyTest/Test2/Util/Grabber.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Util::Grabber;
+
+use base 'Test2::Util::Grabber';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Util/Stash.pm
+++ b/t/lib/MyTest/Test2/Util/Stash.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Util::Stash;
+
+use base 'Test2::Util::Stash';
+use base 'MyTest::Target';
+
+1;

--- a/t/lib/MyTest/Test2/Util/Table/Cell.pm
+++ b/t/lib/MyTest/Test2/Util/Table/Cell.pm
@@ -1,0 +1,6 @@
+package MyTest::Test2::Util::Table::Cell;
+
+use base 'Test2::Util::Table::Cell';
+use base 'MyTest::Target';
+
+1;

--- a/t/modules/Compare.t
+++ b/t/modules/Compare.t
@@ -6,7 +6,7 @@ use warnings;
 # extended bundle)
 BEGIN {
     require Test2::Compare;
-    def ok => (Test2::Compare::convert(undef), "convert returned something to us");
+    def ok => (defined Test2::Compare::convert(undef), "convert returned something to us");
     def ok => ($INC{'Test2/Compare/Undef.pm'}, "loaded the Test2::Compare::Undef module");
 }
 

--- a/t/modules/Compare/Array.t
+++ b/t/modules/Compare/Array.t
@@ -246,4 +246,27 @@ subtest deltas => sub {
     );
 };
 
+{
+  package Foo;
+
+  use Test2::Tools::Basic;
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+  sub new {
+      my $class = shift;
+      bless [ @_ ] , $class;
+  }
+}
+
+subtest objects_as_arrays => sub {
+
+    my $o1 = Foo->new( 'b' ) ;
+    my $o2 = Foo->new( 'b' ) ;
+
+    is ( $o1, $o2, "same" );
+};
+
+
 done_testing;

--- a/t/modules/Compare/Array.t
+++ b/t/modules/Compare/Array.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Array';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Array';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 isa_ok($CLASS, 'Test2::Compare::Base');
 is($CLASS->name, '<ARRAY>', "got name");

--- a/t/modules/Compare/Array.t
+++ b/t/modules/Compare/Array.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Array';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended  -target => 'MyTest::Test2::Compare::Array';;
 
 isa_ok($CLASS, 'Test2::Compare::Base');
 is($CLASS->name, '<ARRAY>', "got name");
@@ -249,11 +235,8 @@ subtest deltas => sub {
 {
   package Foo;
 
-  use Test2::Tools::Basic;
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
+  use base 'MyTest::Target';
+
   sub new {
       my $class = shift;
       bless [ @_ ] , $class;

--- a/t/modules/Compare/Bag.t
+++ b/t/modules/Compare/Bag.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Bag';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Bag';
 
 isa_ok($CLASS, 'Test2::Compare::Base');
 is($CLASS->name, '<BAG>', "got name");

--- a/t/modules/Compare/Bag.t
+++ b/t/modules/Compare/Bag.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Bag';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Bag';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 isa_ok($CLASS, 'Test2::Compare::Base');
 is($CLASS->name, '<BAG>', "got name");

--- a/t/modules/Compare/Base.t
+++ b/t/modules/Compare/Base.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Base';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Base';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $one = $CLASS->new();
 isa_ok($one, $CLASS);

--- a/t/modules/Compare/Base.t
+++ b/t/modules/Compare/Base.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Base';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended  -target => 'MyTest::Test2::Compare::Base';;
 
 my $one = $CLASS->new();
 isa_ok($one, $CLASS);

--- a/t/modules/Compare/Bool.t
+++ b/t/modules/Compare/Bool.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Bool';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Bool';
 
 my $one = $CLASS->new(input => 'foo');
 is($one->name, '<TRUE (foo)>', "Got name");

--- a/t/modules/Compare/Bool.t
+++ b/t/modules/Compare/Bool.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Bool';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Bool';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $one = $CLASS->new(input => 'foo');
 is($one->name, '<TRUE (foo)>', "Got name");

--- a/t/modules/Compare/Custom.t
+++ b/t/modules/Compare/Custom.t
@@ -1,18 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Custom';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Custom';
 
 my $pass = $CLASS->new(code => sub { 1 });
 my $fail = $CLASS->new(code => sub { 0 });

--- a/t/modules/Compare/Custom.t
+++ b/t/modules/Compare/Custom.t
@@ -1,4 +1,18 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Custom';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Custom';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
 
 my $pass = $CLASS->new(code => sub { 1 });
 my $fail = $CLASS->new(code => sub { 0 });

--- a/t/modules/Compare/Delta.t
+++ b/t/modules/Compare/Delta.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Delta';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Delta';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 BEGIN { $ENV{TABLE_TERM_SIZE} = 80 }
 

--- a/t/modules/Compare/Delta.t
+++ b/t/modules/Compare/Delta.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Delta';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Delta';
 
 BEGIN { $ENV{TABLE_TERM_SIZE} = 80 }
 

--- a/t/modules/Compare/Event.t
+++ b/t/modules/Compare/Event.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Event';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Event';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $one = $CLASS->new(etype => 'Ok');
 is($one->name, '<EVENT: Ok>', "got name");

--- a/t/modules/Compare/Event.t
+++ b/t/modules/Compare/Event.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Event';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Event';
 
 my $one = $CLASS->new(etype => 'Ok');
 is($one->name, '<EVENT: Ok>', "got name");

--- a/t/modules/Compare/EventMeta.t
+++ b/t/modules/Compare/EventMeta.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::EventMeta';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::EventMeta';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 use Test2::Util qw/get_tid/;
 

--- a/t/modules/Compare/EventMeta.t
+++ b/t/modules/Compare/EventMeta.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::EventMeta';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::EventMeta';
 
 use Test2::Util qw/get_tid/;
 

--- a/t/modules/Compare/Hash.t
+++ b/t/modules/Compare/Hash.t
@@ -35,7 +35,7 @@ subtest verify => sub {
 
 subtest init => sub {
     my $one = $CLASS->new();
-    ok($one, "args are not required");
+    ok( defined $one, "args are not required");
     is($one->items, {}, "got the items hash");
     is($one->order, [], "got order array");
 
@@ -192,5 +192,28 @@ subtest deltas => sub {
     );
 
 };
+
+{
+  package Foo;
+
+  use Test2::Tools::Basic;
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+  sub new {
+      my $class = shift;
+      bless { @_ } , $class;
+  }
+}
+
+subtest objects_with_hashes => sub {
+
+    my $o1 = Foo->new( b => { foo => 2 } ) ;
+    my $o2 = Foo->new( b => { foo => 2 } ) ;
+
+    is ( $o1, $o2, "same" );
+};
+
 
 done_testing;

--- a/t/modules/Compare/Hash.t
+++ b/t/modules/Compare/Hash.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Hash';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Hash';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 subtest simple => sub {
     my $one = $CLASS->new();

--- a/t/modules/Compare/Hash.t
+++ b/t/modules/Compare/Hash.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Hash';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Hash';
 
 subtest simple => sub {
     my $one = $CLASS->new();
@@ -196,11 +182,8 @@ subtest deltas => sub {
 {
   package Foo;
 
-  use Test2::Tools::Basic;
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
+  use base 'MyTest::Target';
+
   sub new {
       my $class = shift;
       bless { @_ } , $class;

--- a/t/modules/Compare/Meta.t
+++ b/t/modules/Compare/Meta.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Meta';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Meta';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 local *convert = Test2::Compare->can('strict_convert');
 

--- a/t/modules/Compare/Meta.t
+++ b/t/modules/Compare/Meta.t
@@ -24,7 +24,7 @@ subtest simple => sub {
     is($one->name, '<META CHECKS>', "sane name");
     is($one->verify(exists => 0), 0, "Does not verify for non-existant values");
     is($one->verify(exists => 1), 1, "always verifies for existing values");
-    ok($CLASS->new(items => []), "Can provide items");
+    ok(defined $CLASS->new(items => []), "Can provide items");
 };
 
 subtest add_prop => sub {

--- a/t/modules/Compare/Meta.t
+++ b/t/modules/Compare/Meta.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Meta';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Meta';
 
 local *convert = Test2::Compare->can('strict_convert');
 

--- a/t/modules/Compare/Number.t
+++ b/t/modules/Compare/Number.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Number';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Number';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $num    = $CLASS->new(input => '22.0');
 my $untrue = $CLASS->new(input => 0);

--- a/t/modules/Compare/Number.t
+++ b/t/modules/Compare/Number.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Number';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Number';
 
 my $num    = $CLASS->new(input => '22.0');
 my $untrue = $CLASS->new(input => 0);

--- a/t/modules/Compare/Object.t
+++ b/t/modules/Compare/Object.t
@@ -1,4 +1,18 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Object';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Object';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
 
 subtest simple => sub {
     my $one = $CLASS->new;
@@ -106,6 +120,12 @@ subtest add_call => sub {
 {
     package Foo::Bar;
 
+    use Test2::Tools::Basic qw( fail );
+    main::imported_ok(qw/fail/);
+  
+    use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+    use overload '""' => sub { $_[0] };
+
     sub foo { 'foo' }
     sub baz { 'baz' }
     sub one { 1 }
@@ -113,6 +133,12 @@ subtest add_call => sub {
     sub args { shift; +{@_} }
 
     package Fake::Fake;
+
+    use Test2::Tools::Basic qw( fail );
+    main::imported_ok(qw/fail/);
+  
+    use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+    use overload '""' => sub { $_[0] };
 
     sub foo { 'xxx' }
     sub one { 2 }

--- a/t/modules/Compare/Object.t
+++ b/t/modules/Compare/Object.t
@@ -26,7 +26,7 @@ subtest simple => sub {
 
     is($one->object_base, 'UNIVERSAL', "Correct object base");
 
-    ok($CLASS->new(calls => []), "Can specify a calls array")
+    ok(defined $CLASS->new(calls => []), "Can specify a calls array")
 };
 
 subtest verify => sub {

--- a/t/modules/Compare/Object.t
+++ b/t/modules/Compare/Object.t
@@ -1,18 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Object';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Object';
 
 subtest simple => sub {
     my $one = $CLASS->new;
@@ -120,11 +107,7 @@ subtest add_call => sub {
 {
     package Foo::Bar;
 
-    use Test2::Tools::Basic qw( fail );
-    main::imported_ok(qw/fail/);
-  
-    use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-    use overload '""' => sub { $_[0] };
+    use base 'MyTest::Target';
 
     sub foo { 'foo' }
     sub baz { 'baz' }
@@ -134,11 +117,7 @@ subtest add_call => sub {
 
     package Fake::Fake;
 
-    use Test2::Tools::Basic qw( fail );
-    main::imported_ok(qw/fail/);
-  
-    use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-    use overload '""' => sub { $_[0] };
+    use base 'MyTest::Target';
 
     sub foo { 'xxx' }
     sub one { 2 }

--- a/t/modules/Compare/OrderedSubset.t
+++ b/t/modules/Compare/OrderedSubset.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::OrderedSubset';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::OrderedSubset';
 
 isa_ok($CLASS, 'Test2::Compare::Base');
 is($CLASS->name, '<ORDERED SUBSET>', "got name");
@@ -111,11 +97,8 @@ subtest deltas => sub {
 {
   package Foo;
 
-  use Test2::Tools::Basic;
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
+  use base 'MyTest::Target';
+
   sub new {
       my $class = shift;
       bless [ @_ ] , $class;

--- a/t/modules/Compare/OrderedSubset.t
+++ b/t/modules/Compare/OrderedSubset.t
@@ -108,4 +108,25 @@ subtest deltas => sub {
     );
 };
 
+{
+  package Foo;
+
+  use Test2::Tools::Basic;
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+  sub new {
+      my $class = shift;
+      bless [ @_ ] , $class;
+  }
+}
+
+subtest object_as_arrays => sub {
+
+    my $o1 = Foo->new( 'b') ;
+
+    is ( $o1 , subset{  item 'b' }, "same" );
+};
+
 done_testing;

--- a/t/modules/Compare/OrderedSubset.t
+++ b/t/modules/Compare/OrderedSubset.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::OrderedSubset';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::OrderedSubset';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 isa_ok($CLASS, 'Test2::Compare::Base');
 is($CLASS->name, '<ORDERED SUBSET>', "got name");

--- a/t/modules/Compare/Pattern.t
+++ b/t/modules/Compare/Pattern.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Pattern';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Pattern';
 
 my $one = $CLASS->new(pattern => qr/HASH/);
 isa_ok($one, $CLASS, 'Test2::Compare::Base');

--- a/t/modules/Compare/Pattern.t
+++ b/t/modules/Compare/Pattern.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Pattern';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Pattern';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $one = $CLASS->new(pattern => qr/HASH/);
 isa_ok($one, $CLASS, 'Test2::Compare::Base');

--- a/t/modules/Compare/Ref.t
+++ b/t/modules/Compare/Ref.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Ref';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Ref';
 
 my $ref = sub { 1 };
 my $one = $CLASS->new(input => $ref);

--- a/t/modules/Compare/Ref.t
+++ b/t/modules/Compare/Ref.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Ref';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Ref';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $ref = sub { 1 };
 my $one = $CLASS->new(input => $ref);

--- a/t/modules/Compare/Regex.t
+++ b/t/modules/Compare/Regex.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Regex';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Regex';
 
 my $one = $CLASS->new(input => qr/abc/i);
 

--- a/t/modules/Compare/Regex.t
+++ b/t/modules/Compare/Regex.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Regex';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Regex';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $one = $CLASS->new(input => qr/abc/i);
 

--- a/t/modules/Compare/Scalar.t
+++ b/t/modules/Compare/Scalar.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Scalar';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Scalar';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $one = $CLASS->new(item => 'foo');
 is($one->name, '<SCALAR>', "got name");

--- a/t/modules/Compare/Scalar.t
+++ b/t/modules/Compare/Scalar.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Scalar';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Scalar';
 
 my $one = $CLASS->new(item => 'foo');
 is($one->name, '<SCALAR>', "got name");

--- a/t/modules/Compare/Set.t
+++ b/t/modules/Compare/Set.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Set';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Set';
 
 subtest construction => sub {
     my $one = $CLASS->new();

--- a/t/modules/Compare/Set.t
+++ b/t/modules/Compare/Set.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Set';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Set';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 subtest construction => sub {
     my $one = $CLASS->new();

--- a/t/modules/Compare/String.t
+++ b/t/modules/Compare/String.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::String';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::String';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $number = $CLASS->new(input => '22.0');
 my $string = $CLASS->new(input => 'hello');

--- a/t/modules/Compare/String.t
+++ b/t/modules/Compare/String.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::String';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::String';
 
 my $number = $CLASS->new(input => '22.0');
 my $string = $CLASS->new(input => 'hello');

--- a/t/modules/Compare/Undef.t
+++ b/t/modules/Compare/Undef.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Undef';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Undef';
 
 my $undef = $CLASS->new();
 my $isdef = $CLASS->new(negate => 1);

--- a/t/modules/Compare/Undef.t
+++ b/t/modules/Compare/Undef.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Undef';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Undef';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $undef = $CLASS->new();
 my $isdef = $CLASS->new(negate => 1);

--- a/t/modules/Compare/Wildcard.t
+++ b/t/modules/Compare/Wildcard.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Wildcard';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Wildcard';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 my $one = $CLASS->new(expect => 'foo');
 isa_ok($one, $CLASS, 'Test2::Compare::Base');

--- a/t/modules/Compare/Wildcard.t
+++ b/t/modules/Compare/Wildcard.t
@@ -18,9 +18,9 @@ sub CLASS() { $CLASS }
 my $one = $CLASS->new(expect => 'foo');
 isa_ok($one, $CLASS, 'Test2::Compare::Base');
 
-ok($CLASS->new(expect => 0), "0 is a valid expect value");
-ok($CLASS->new(expect => undef), "undef is a valid expect value");
-ok($CLASS->new(expect => ''), "'' is a valid expect value");
+ok(defined $CLASS->new(expect => 0), "0 is a valid expect value");
+ok(defined $CLASS->new(expect => undef), "undef is a valid expect value");
+ok(defined $CLASS->new(expect => ''), "'' is a valid expect value");
 
 like(
     dies { $CLASS->new() },

--- a/t/modules/Compare/Wildcard.t
+++ b/t/modules/Compare/Wildcard.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Wildcard';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Wildcard';
 
 my $one = $CLASS->new(expect => 'foo');
 isa_ok($one, $CLASS, 'Test2::Compare::Base');

--- a/t/modules/Mock.t
+++ b/t/modules/Mock.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Mock';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Mock';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 use Test2::API qw/context/;
 
 use Scalar::Util qw/blessed/;

--- a/t/modules/Mock.t
+++ b/t/modules/Mock.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Mock';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Mock';
 use Test2::API qw/context/;
 
 use Scalar::Util qw/blessed/;

--- a/t/modules/Require/AuthorTesting.t
+++ b/t/modules/Require/AuthorTesting.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Require::AuthorTesting';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Require::AuthorTesting';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 {
     local %ENV = %ENV;

--- a/t/modules/Require/AuthorTesting.t
+++ b/t/modules/Require/AuthorTesting.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Require::AuthorTesting';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Require::AuthorTesting';
 
 {
     local %ENV = %ENV;

--- a/t/modules/Require/EnvVar.t
+++ b/t/modules/Require/EnvVar.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Require::EnvVar';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Require::EnvVar';
 
 {
     local %ENV = %ENV;

--- a/t/modules/Require/EnvVar.t
+++ b/t/modules/Require/EnvVar.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Require::EnvVar';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Require::EnvVar';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 {
     local %ENV = %ENV;

--- a/t/modules/Require/Fork.t
+++ b/t/modules/Require/Fork.t
@@ -9,22 +9,8 @@ BEGIN {
     *Test2::Util::CAN_FORK = sub { $forks };
 }
 
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Require::Fork';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Require::Fork';
 
 {
     $forks = 0;

--- a/t/modules/Require/Fork.t
+++ b/t/modules/Require/Fork.t
@@ -9,7 +9,22 @@ BEGIN {
     *Test2::Util::CAN_FORK = sub { $forks };
 }
 
-use Test2::Bundle::Extended -target => 'Test2::Require::Fork';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Require::Fork';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 {
     $forks = 0;

--- a/t/modules/Require/Module.t
+++ b/t/modules/Require/Module.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Require::Module';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Require::Module';
 
 is($CLASS->skip('Scalar::Util'), undef, "will not skip, module installed");
 is($CLASS->skip('Scalar::Util', 0.5), undef, "will not skip, module at sufficient version");

--- a/t/modules/Require/Module.t
+++ b/t/modules/Require/Module.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Require::Module';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Require::Module';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 is($CLASS->skip('Scalar::Util'), undef, "will not skip, module installed");
 is($CLASS->skip('Scalar::Util', 0.5), undef, "will not skip, module at sufficient version");

--- a/t/modules/Require/Perl.t
+++ b/t/modules/Require/Perl.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Require::Perl';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Require::Perl';
 
 is($CLASS->skip('v5.6'), undef, "will not skip");
 is($CLASS->skip('v10.10'), 'Perl v10.10.0 required', "will skip");

--- a/t/modules/Require/Perl.t
+++ b/t/modules/Require/Perl.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Require::Perl';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Require::Perl';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 is($CLASS->skip('v5.6'), undef, "will not skip");
 is($CLASS->skip('v10.10'), 'Perl v10.10.0 required', "will skip");

--- a/t/modules/Require/RealFork.t
+++ b/t/modules/Require/RealFork.t
@@ -9,7 +9,22 @@ BEGIN {
     *Test2::Util::CAN_REALLY_FORK = sub { $forks };
 }
 
-use Test2::Bundle::Extended -target => 'Test2::Require::RealFork';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Require::RealFork';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 {
     $forks = 0;

--- a/t/modules/Require/RealFork.t
+++ b/t/modules/Require/RealFork.t
@@ -9,22 +9,8 @@ BEGIN {
     *Test2::Util::CAN_REALLY_FORK = sub { $forks };
 }
 
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Require::RealFork';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Require::RealFork';
 
 {
     $forks = 0;

--- a/t/modules/Require/Threads.t
+++ b/t/modules/Require/Threads.t
@@ -9,22 +9,8 @@ BEGIN {
     *Test2::Util::CAN_THREAD = sub { $threads };
 }
 
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Require::Threads';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Require::Threads';
 
 {
     $threads = 0;

--- a/t/modules/Require/Threads.t
+++ b/t/modules/Require/Threads.t
@@ -9,7 +9,22 @@ BEGIN {
     *Test2::Util::CAN_THREAD = sub { $threads };
 }
 
-use Test2::Bundle::Extended -target => 'Test2::Require::Threads';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Require::Threads';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 {
     $threads = 0;

--- a/t/modules/Todo.t
+++ b/t/modules/Todo.t
@@ -1,6 +1,20 @@
-use Test2::Bundle::Extended -target => 'Test2::Todo';
+use Test2::Bundle::Extended;
 
-my $todo = Test2::Todo->new(reason => 'xyz');
+{ package Target;
+
+  use base 'Test2::Todo';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
+
+my $todo = $CLASS->new(reason => 'xyz');
 def isa_ok => ($todo, $CLASS);
 def ok => ((grep {$_->{code} == $todo->_filter} @{Test2::API::test2_stack->top->_pre_filters}), "filter added");
 def is => ($todo->reason, 'xyz', "got reason");
@@ -28,7 +42,7 @@ is($filtered_diag->message, $diag->message, "new note has the same message");
 my $events = intercept {
     ok(0, 'fail');
 
-    my $todo = Test2::Todo->new(reason => 'xyz');
+    my $todo = $CLASS->new(reason => 'xyz');
     ok(0, 'todo fail');
     $todo = undef;
 

--- a/t/modules/Todo.t
+++ b/t/modules/Todo.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Todo';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload eq => sub { "$_[0]" eq "$_[1]" };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Todo';
 
 my $todo = $CLASS->new(reason => 'xyz');
 def isa_ok => ($todo, $CLASS);

--- a/t/modules/Todo.t
+++ b/t/modules/Todo.t
@@ -8,6 +8,7 @@ use Test2::Bundle::Extended;
   main::imported_ok(qw/fail/);
   
   use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload eq => sub { "$_[0]" eq "$_[1]" };
 }
 
 my $CLASS = 'Target';

--- a/t/modules/Tools/Basic.t
+++ b/t/modules/Tools/Basic.t
@@ -1,16 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::Basic';
-
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::Basic';
 
 {
     package Temp;

--- a/t/modules/Tools/Basic.t
+++ b/t/modules/Tools/Basic.t
@@ -1,4 +1,16 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Basic';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::Basic';
+
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 {
     package Temp;

--- a/t/modules/Tools/Class.t
+++ b/t/modules/Tools/Class.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Class';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::Class';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 {
     package Temp;
@@ -9,6 +24,12 @@ use Test2::Bundle::Extended -target => 'Test2::Tools::Class';
 
 {
     package X;
+
+    use Test2::Tools::Basic qw( fail );
+    main::imported_ok(qw/fail/);
+
+    use overload 'bool' => sub { fail( 'illegal use of overloaded bool') } ;
+    use overload '""' => sub { $_[0] };
 
     sub can {
         my $thing = pop;
@@ -37,8 +58,11 @@ use Test2::Bundle::Extended -target => 'Test2::Tools::Class';
 
 {
     package My::String;
-    use overload '""' => sub { "xxx\nyyy" };
+    use Test2::Tools::Basic qw( fail );
+    main::imported_ok(qw/fail/);
 
+    use overload '""' => sub { "xxx\nyyy" };
+    use overload 'bool' => sub { fail( 'illegal use of overloaded bool') } ;
     sub DOES { 0 }
 }
 

--- a/t/modules/Tools/Class.t
+++ b/t/modules/Tools/Class.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::Class';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::Class';
 
 {
     package Temp;

--- a/t/modules/Tools/ClassicCompare.t
+++ b/t/modules/Tools/ClassicCompare.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::ClassicCompare';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::ClassicCompare';
 
 BEGIN { $ENV{TABLE_TERM_SIZE} = 80 }
 

--- a/t/modules/Tools/ClassicCompare.t
+++ b/t/modules/Tools/ClassicCompare.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::ClassicCompare';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::ClassicCompare';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 BEGIN { $ENV{TABLE_TERM_SIZE} = 80 }
 
@@ -72,6 +87,12 @@ is_deeply(
 
 {
     package Foo;
+
+    use Test2::Tools::Basic qw( fail );
+
+    main::imported_ok(qw/fail/);
+  
+    use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
     use overload '""' => sub { 'xxx' };
 }
 my $foo = bless({}, 'Foo');

--- a/t/modules/Tools/Compare.t
+++ b/t/modules/Tools/Compare.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Compare';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::Compare';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 use Test2::Util::Table();
 sub table { join "\n" => Test2::Util::Table::table(@_) }
 

--- a/t/modules/Tools/Compare.t
+++ b/t/modules/Tools/Compare.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::Compare';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::Compare';
 use Test2::Util::Table();
 sub table { join "\n" => Test2::Util::Table::table(@_) }
 

--- a/t/modules/Tools/Defer.t
+++ b/t/modules/Tools/Defer.t
@@ -16,7 +16,21 @@ BEGIN {
     def is => ({}, [], "a hash is not an array");
 }
 
-use Test2::Bundle::Extended -target => 'Test2::Tools::Defer';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::Defer';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
 
 sub capture(&) {
     my $code = shift;

--- a/t/modules/Tools/Defer.t
+++ b/t/modules/Tools/Defer.t
@@ -16,21 +16,8 @@ BEGIN {
     def is => ({}, [], "a hash is not an array");
 }
 
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::Defer';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::Defer';
 
 sub capture(&) {
     my $code = shift;

--- a/t/modules/Tools/Encoding.t
+++ b/t/modules/Tools/Encoding.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::Encoding';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::Encoding';
 
 require Test2::Formatter::TAP;
 

--- a/t/modules/Tools/Encoding.t
+++ b/t/modules/Tools/Encoding.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Encoding';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::Encoding';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 require Test2::Formatter::TAP;
 

--- a/t/modules/Tools/Exception.t
+++ b/t/modules/Tools/Exception.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Exception';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::Exception';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 {
     package Foo;

--- a/t/modules/Tools/Exception.t
+++ b/t/modules/Tools/Exception.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::Exception';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::Exception';
 
 {
     package Foo;

--- a/t/modules/Tools/Exports.t
+++ b/t/modules/Tools/Exports.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Exports';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::Exports';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 {
     package Temp;

--- a/t/modules/Tools/Exports.t
+++ b/t/modules/Tools/Exports.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::Exports';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::Exports';
 
 {
     package Temp;

--- a/t/modules/Tools/Grab.t
+++ b/t/modules/Tools/Grab.t
@@ -1,18 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Util::Grabber';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Util::Grabber';
 
 use Test2::Tools::Grab;
 

--- a/t/modules/Tools/Grab.t
+++ b/t/modules/Tools/Grab.t
@@ -1,4 +1,18 @@
-use Test2::Bundle::Extended -target => 'Test2::Util::Grabber';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Util::Grabber';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
 
 use Test2::Tools::Grab;
 

--- a/t/modules/Tools/Mock.t
+++ b/t/modules/Tools/Mock.t
@@ -1,18 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Compare::Custom';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Compare::Custom';
 
 use Test2::Tools::Mock qw{
     mock_obj mock_class

--- a/t/modules/Tools/Mock.t
+++ b/t/modules/Tools/Mock.t
@@ -1,4 +1,18 @@
-use Test2::Bundle::Extended -target => 'Test2::Compare::Custom';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Compare::Custom';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
 
 use Test2::Tools::Mock qw{
     mock_obj mock_class

--- a/t/modules/Tools/Ref.t
+++ b/t/modules/Tools/Ref.t
@@ -1,19 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::Ref';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
-
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::Ref';
 
 {
     package Temp;

--- a/t/modules/Tools/Ref.t
+++ b/t/modules/Tools/Ref.t
@@ -1,4 +1,19 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Ref';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::Ref';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
+
 
 {
     package Temp;

--- a/t/modules/Tools/Subtest.t
+++ b/t/modules/Tools/Subtest.t
@@ -1,18 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::Subtest';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::Subtest';
 
 use Test2::Tools::Subtest qw/subtest_streamed subtest_buffered/;
 

--- a/t/modules/Tools/Subtest.t
+++ b/t/modules/Tools/Subtest.t
@@ -1,4 +1,18 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Subtest';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::Subtest';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
 
 use Test2::Tools::Subtest qw/subtest_streamed subtest_buffered/;
 

--- a/t/modules/Tools/Warnings.t
+++ b/t/modules/Tools/Warnings.t
@@ -1,4 +1,18 @@
-use Test2::Bundle::Extended -target => 'Test2::Tools::Warnings';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Tools::Warnings';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
 
 {
     package Foo;

--- a/t/modules/Tools/Warnings.t
+++ b/t/modules/Tools/Warnings.t
@@ -1,18 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Tools::Warnings';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Tools::Warnings';
 
 {
     package Foo;

--- a/t/modules/Util/Grabber.t
+++ b/t/modules/Util/Grabber.t
@@ -1,18 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Util::Grabber';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Util::Grabber';
 
 ok(1, "initializing");
 

--- a/t/modules/Util/Grabber.t
+++ b/t/modules/Util/Grabber.t
@@ -1,4 +1,18 @@
-use Test2::Bundle::Extended -target => 'Test2::Util::Grabber';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Util::Grabber';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
 
 ok(1, "initializing");
 

--- a/t/modules/Util/Stash.t
+++ b/t/modules/Util/Stash.t
@@ -1,18 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Util::Stash';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Util::Stash';
 
 use Test2::Util::Stash qw{
     get_stash

--- a/t/modules/Util/Stash.t
+++ b/t/modules/Util/Stash.t
@@ -1,4 +1,18 @@
-use Test2::Bundle::Extended -target => 'Test2::Util::Stash';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Util::Stash';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
 
 use Test2::Util::Stash qw{
     get_stash

--- a/t/modules/Util/Table/Cell.t
+++ b/t/modules/Util/Table/Cell.t
@@ -1,4 +1,18 @@
-use Test2::Bundle::Extended -target => 'Test2::Util::Table::Cell';
+use Test2::Bundle::Extended;
+
+{ package Target;
+
+  use base 'Test2::Util::Table::Cell';
+
+  use Test2::Tools::Basic qw( fail );
+  main::imported_ok(qw/fail/);
+  
+  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
+  use overload '""' => sub { $_[0] };
+}
+
+my $CLASS = 'Target';
+sub CLASS() { $CLASS }
 
 subtest sanitization => sub {
     my $unsanitary = <<"    EOT";

--- a/t/modules/Util/Table/Cell.t
+++ b/t/modules/Util/Table/Cell.t
@@ -1,18 +1,5 @@
-use Test2::Bundle::Extended;
-
-{ package Target;
-
-  use base 'Test2::Util::Table::Cell';
-
-  use Test2::Tools::Basic qw( fail );
-  main::imported_ok(qw/fail/);
-  
-  use overload bool => sub { fail( 'illegal use of overloaded bool') } ;
-  use overload '""' => sub { $_[0] };
-}
-
-my $CLASS = 'Target';
-sub CLASS() { $CLASS }
+use lib './t/lib';
+use Test2::Bundle::Extended -target => 'MyTest::Test2::Util::Table::Cell';
 
 subtest sanitization => sub {
     my $unsanitary = <<"    EOT";


### PR DESCRIPTION
The previous attempt added overloaded `bool` and `stringify` operators to `Test2::Compare::Base` to ensure that all tests which used a `Test2::??` class as a target would fail if used in a boolean context.  As indicated by PR #115 , this broke code which uses a class derived from `Test2::Compare::Base` in a boolean context to check for definedness.

This attempt instead uses proxy classes in the test code which inherit from the specific `Test2` class being tested, adding overloads for `bool` and `stringify`.  It thus avoids the problems caused by the first attempt.  Unfortunately, as there is no equivalent of `Test::Lib` in the basic suite (that I know of), this results in duplicated boilerplate code.

The code has been tested against the released versions of

- Test2::Tools::EventDumper: 0.000007
- Test2::Harness: 0.000013
- Test2::AsyncSubtest: 0.000018
- Test2::Tools::AfterSubtest: 0.001
- Test2::Plugin::SpecDeclare: 0.000003
- Test2::Tools::Expressive: 0.02
- Test2::Tools::Explain: 0.02
- Test2::Workflow: 0.000018
- Test2::Plugin::NoWarnings: 0.05
