### PR TITLE
Test tools class isa ok

### DIFF
--- a/lib/Test2/Tools/Class.pm
+++ b/lib/Test2/Tools/Class.pm
@@ -38,9 +38,7 @@ BEGIN {
 
             $name ||= @items == 1 ? "$thing_name\->$op('$items[0]')" : "$thing_name\->$op(...)";
 
-            my $non_empty_string = !ref($thing) && length($thing);
-
-            unless (defined($thing) && (blessed($thing) || $non_empty_string)) {
+            unless (defined($thing) && (blessed($thing) || !ref($thing) && length($thing))) {
                 my $thing = defined($thing)
                     ? ref($thing) || "'$thing'"
                     : '<undef>';

--- a/lib/Test2/Tools/Class.pm
+++ b/lib/Test2/Tools/Class.pm
@@ -38,7 +38,9 @@ BEGIN {
 
             $name ||= @items == 1 ? "$thing_name\->$op('$items[0]')" : "$thing_name\->$op(...)";
 
-            unless ($thing && (blessed($thing) || !ref($thing))) {
+            my $non_empty_string = !ref($thing) && length($thing);
+
+            unless (defined($thing) && (blessed($thing) || $non_empty_string)) {
                 my $thing = defined($thing)
                     ? ref($thing) || "'$thing'"
                     : '<undef>';

--- a/t/regression/Test2-Tools-Class.t
+++ b/t/regression/Test2-Tools-Class.t
@@ -1,0 +1,17 @@
+use Test2::Tools::Class;
+use strict;
+use warnings;
+
+{
+    package My::Object;
+    use overload 'bool' => sub {$_[0]->{value}}
+}
+
+my $true_value  = bless {value => 1}, 'My::Object';
+my $false_value = bless {value => 0}, 'My::Object';
+
+isa_ok($true_value,  ['My::Object'], 'isa_ok when object overloads to true');
+isa_ok($false_value, ['My::Object'], 'isa_ok when object overloads to false');
+
+require Test2::Tools::Basic;
+Test2::Tools::Basic::done_testing();


### PR DESCRIPTION
This revision fixes #119.

`isa_ok` fails when an object that overloads boolean comparison operators evaluates to a false value.  For example:

```perl
use Test2::Tools::Class;
use version;
my $thing = version->parse(0);
# not ok 1 - version=HASH->isa('version')
isa_ok($thing, 'version');
```