### PR TITLE
Fix Test2::Mock doesn't accept non-ref values

### DIFF
--- a/lib/Test2/Mock.pm
+++ b/lib/Test2/Mock.pm
@@ -303,9 +303,13 @@ sub _parse_inject {
 
     my ($is, $field, $val);
 
-    if (!ref($arg)) {
-        $is    = $arg if $arg =~ m/^(rw|ro|wo)$/;
+    if(defined($arg) && !ref($arg) && $arg =~ m/^(rw|ro|wo)$/) {
+        $is    = $arg;
         $field = $param;
+    }
+    elsif (!ref($arg)) {
+        $val = $arg;
+        $is  = 'val';
     }
     elsif (reftype($arg) eq 'HASH') {
         $field = delete $arg->{field} || $param;
@@ -320,9 +324,9 @@ sub _parse_inject {
         croak "The following keys are not valid when defining a mocked sub with a hashref: " . join(", " => keys %$arg)
             if keys %$arg;
     }
-
-    confess "'$arg' is not a valid argument when defining a mocked sub"
-        unless $is;
+    else {
+        confess "'$arg' is not a valid argument when defining a mocked sub";
+    }
 
     my $sub;
     if ($is eq 'rw') {

--- a/t/regression/Test2-Mock.t
+++ b/t/regression/Test2-Mock.t
@@ -1,0 +1,45 @@
+use Test2::Bundle::Extended;
+use Test2::Mock;
+
+my $mock;
+
+ok( lives {
+        $mock = Test2::Mock->new(
+            class => 'Fake',
+            add   => [
+                foo => 'string',
+                bar => undef,
+            ],
+        );
+    },
+    'Did not die when adding plain value'
+);
+
+isa_ok(
+    $mock,
+    'Test2::Mock'
+);
+
+is( Fake::foo(),
+    'string',
+    'Correct value returned for add when plain string given' 
+);
+
+is( Fake::bar(),
+    undef,
+    'Correct value returned for add when undef given'
+);
+
+$mock->override(foo => undef, bar => 'string');
+
+is( Fake::foo(),
+    undef,
+    'Correct value returned for override when undef given'
+);
+
+is( Fake::bar(),
+    'string',
+    'Correct value returned for override when plain string given'
+);
+
+done_testing;


### PR DESCRIPTION
Adding or overriding a symbol using a non-reference for the value causes
an error:

```perl
# 'foo' is not a valid argument when defining a mocked sub
$mock->override( foo => 'foo' );
```