### PR TITLE
Compare the bag containing duplicate items correctly

### DIFF
--- a/lib/Test2/Compare/Bag.pm
+++ b/lib/Test2/Compare/Bag.pm
@@ -60,6 +60,7 @@ sub deltas {
 
         my $match = 0;
         for my $idx (0..$#list) {
+            next unless exists $unmatched{$idx};
             my $val = $list[$idx];
             my $deltas = $check->run(
                 id      => [ARRAY => $idx],

--- a/t/modules/Compare/Bag.t
+++ b/t/modules/Compare/Bag.t
@@ -115,6 +115,38 @@ subtest deltas => sub {
         },
         "Got 2 deltas for extra items"
     );
+
+    subtest 'duplicate items' => sub {
+        my $items = ['a', 'a'];
+        my $one = $CLASS->new(items => $items);
+
+        like(
+            [$one->deltas(%params, got => ['a', 'a'])],
+            [],
+            "No delta, no diff"
+        );
+
+        like(
+            [$one->deltas(%params, got => ['a', 'a', 'a'])],
+            [],
+            "No delta, not checking ending"
+        );
+
+        $one->set_ending(1);
+        like(
+            [$one->deltas(%params, got => ['a', 'a', 'a'])],
+            array {
+                item 0 => {
+                    dne   => 'check',
+                    id    => [ARRAY => 2],
+                    got   => 'a',
+                    check => DNE,
+                };
+                end(),
+            },
+            "Got the delta for extra item"
+        );
+    };
 };
 
 done_testing;


### PR DESCRIPTION
This test case fails due to compare duplicate items.

```perl
use Test2::Bundle::Extended;

is ['a', 'a'], bag {
    item 'a';
    item 'a';
    end();
};

done_testing;
```

```
# Seeded srand with seed '20170628' from local date.
not ok 1
# Failed test at bag.pl line 7.
# +------+-----------------------+---------+------------------+------+
# | PATH | GOT                   | OP      | CHECK            | LNs  |
# +------+-----------------------+---------+------------------+------+
# |      | ARRAY(0x7f983f028418) |         | <BAG>            | 3, 7 |
# | [1]  | a                     | !exists | <DOES NOT EXIST> |      |
# +------+-----------------------+---------+------------------+------+
1..1
```

This p-r checks unmached item for skipping items already matched.