### PR TITLE
Add another 5.10 version to the check

### DIFF
--- a/lib/Test2/Util/Stash.pm
+++ b/lib/Test2/Util/Stash.pm
@@ -58,7 +58,7 @@ sub _parse_symbol {
         return $symbol;
     }
 
-    utf8::downgrade($symbol) if $] == 5.010001; # prevent crash on 5.10.0
+    utf8::downgrade($symbol) if $] == 5.010000; # prevent crash on 5.10.0
     my ($sig, $pkg, $name) = ($symbol =~ m/^(\W?)(.*::)?([^:]+)$/)
         or croak "Invalid symbol: '$symbol'";
 


### PR DESCRIPTION
The CPAN testers reports are demonstrating I didn't check for sufficient 'versions' of 5.10 with my little fix for issue #129.

http://www.cpantesters.org/cpan/report/64b2c3d2-b1df-11e7-a2a8-d0c13ad602b4