### PR TITLE
Update travis threaded perl versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: perl
 perl:
   - "5.8"
-  - "5.8-thr"
   - "5.10"
   - "5.12"
   - "5.14"
   - "5.16"
-  - "5.18"
-  - "5.20-thr"
-  - "5.22-thr"
-  - "5.24-thr"
+  - "5.18-shrplib"
+  - "5.20-shrplib"
+  - "5.22-shrplib"
+  - "5.24-shrplib"
 before_install:
   - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
   - source ~/travis-perl-helpers/init --auto


### PR DESCRIPTION
The current travis docs list 4 threaded perl targets, 5.18-shrplib
through 5.24-shrplib.

The seem to have deprecated and removed the -thr versions and removed
them from s3.

See: https://docs.travis-ci.com/user/languages/perl/#Perl-runtimes-with--Duseshrplib