### PR TITLE
Add support for comparison of references to VSTRING object

### DIFF
--- a/lib/Test2/Compare.pm
+++ b/lib/Test2/Compare.pm
@@ -152,7 +152,7 @@ sub _convert {
     return Test2::Compare::Regex->new(input => $thing)
         if $type eq 'REGEXP';
 
-    if ($type eq 'SCALAR') {
+    if ($type eq 'SCALAR' || $type eq 'VSTRING') {
         my $nested = _convert($$thing, $config);
         return Test2::Compare::Scalar->new(item => $nested);
     }

--- a/lib/Test2/Compare/Scalar.pm
+++ b/lib/Test2/Compare/Scalar.pm
@@ -30,7 +30,7 @@ sub verify {
     return 0 unless $exists;
     return 0 unless defined $got;
     return 0 unless ref($got);
-    return 0 unless reftype($got) eq 'SCALAR';
+    return 0 unless reftype($got) eq 'SCALAR' || reftype($got) eq 'VSTRING';
     return 1;
 }
 

--- a/t/modules/Compare.t
+++ b/t/modules/Compare.t
@@ -116,6 +116,7 @@ subtest convert => sub {
         [sub { 1 }, 'Ref', 'Custom'],
         [\*STDERR, 'Ref',    'Ref'],
         [\'foo',   'Scalar', 'Scalar'],
+        [\v1.2.3,  'Scalar', 'Scalar'],
         [$true,    'Scalar', 'Scalar'],
         [$false,   'Scalar', 'Scalar'],
 

--- a/t/modules/Tools/Compare.t
+++ b/t/modules/Tools/Compare.t
@@ -45,6 +45,11 @@ subtest is => sub {
         def ok => (is($true,  $true,  "true scalar ref is itself"),  "true scalar ref is itself");
         def ok => (is($false, $false, "false scalar ref is itself"), "false scalar ref is itself");
 
+        def ok => (is(v1.2.3, v1.2.3, 'vstring pass'), 'vstring pass');
+        def ok => (is(\v1.2.3, \v1.2.3, 'vstring refs pass'), 'vstring refs pass');
+        def ok => (!is(v1.2.3, v1.2.4, 'vstring fail'), 'vstring fail');
+        def ok => (!is(\v1.2.3, \v1.2.4, 'vstring refs fail'), 'vstring refs fail');
+
         my $x = \\"123";
         def ok => (is($x, \\"123", "Ref-Ref check 1"), "Ref-Ref check 1");
 
@@ -123,6 +128,38 @@ subtest is => sub {
             event Ok => sub {
                 call pass => T();
                 call name => "false scalar ref is itself";
+            };
+
+            event Ok => sub {
+                call pass => T();
+                call name => 'vstring pass';
+            };
+
+            event Ok => sub {
+                call pass => T();
+                call name => 'vstring refs pass';
+            };
+
+            fail_events Ok => sub {
+                call pass => F();
+                call name => 'vstring fail';
+            };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/GOT OP CHECK/],
+                    rows   => [['\N{U+1}\N{U+2}\N{U+3}', 'eq', '\N{U+1}\N{U+2}\N{U+4}']],
+                );
+            };
+
+            fail_events Ok => sub {
+                call pass => F();
+                call name => 'vstring refs fail';
+            };
+            event Diag => sub {
+                call message => table(
+                    header => [qw/PATH GOT OP CHECK/],
+                    rows   => [['$*', '\N{U+1}\N{U+2}\N{U+3}', 'eq', '\N{U+1}\N{U+2}\N{U+4}']],
+                );
             };
 
             event Ok => sub {


### PR DESCRIPTION
Vstring is now being treated as string in deep comparison.

For enhancement #99 

Done as part of CPAN Pull Request Challenge.