### PR TITLE
Add support for 'precision' for floats

### DIFF
--- a/t/modules/Compare/Float.t
+++ b/t/modules/Compare/Float.t
@@ -3,6 +3,7 @@ use Test2::Bundle::Extended -target => 'Test2::Compare::Float';
 my $num     = $CLASS->new(input => '22.0', tolerance => .001);
 my $neg_num = $CLASS->new(input => -22,    tolerance => .001);
 my $untrue  = $CLASS->new(input => 0);
+my $pre_num = $CLASS->new(input => '22.0', precision => 3);
 
 isa_ok($num,    $CLASS, 'Test2::Compare::Base');
 isa_ok($untrue, $CLASS, 'Test2::Compare::Base');
@@ -16,6 +17,17 @@ subtest name => sub {
     is($num->name,    '22.0 +/- ' . $num->tolerance, "got expected name for number");
     is($untrue->name, '0 +/- ' . $untrue->tolerance, "got expected name for 0");
     # Note: string length of mantissa varies by perl install, e.g. 1e-08 vs 1e-008
+
+    is($pre_num->name, '22.000', "got expected 3 digits of precision in name for 22.0, precision=5");
+    is($CLASS->new(input => '100.123456789012345', precision => 10)->name,
+      '100.1234567890',
+      'got expected precision in name at precision=10');
+    is($CLASS->new(input => '100.123456789012345', precision => 15)->name,
+      sprintf('%.*f', 15, '100.123456789012345'),
+      'got expected precision in name at precision=15');  # likely not 100.123456789012345!
+    is($CLASS->new(input => '100.123456789012345', precision => 20)->name,
+      sprintf('%.*f', 20, '100.123456789012345'),
+      'got expected precision in name at precision=20');
 };
 
 subtest operator => sub {
@@ -49,7 +61,7 @@ subtest verify => sub {
     ok($untrue->verify(exists => 1, got => '-0.0'), '-0.0 == 0');
 };
 
-subtest verify_float => sub {
+subtest verify_float_tolerance => sub {
   ok($num->verify(exists => 1, got => "22.0"),     '22.0    == 22 +/- .001');
   ok($num->verify(exists => 1, got => "22.0009"),  '22.0009 == 22 +/- .001');
   ok($num->verify(exists => 1, got => "21.9991"),  '21.9991 == 22 +/- .001');
@@ -71,8 +83,31 @@ subtest verify_float => sub {
   ok(!$neg_num->verify(exists => 1, got => -21.9989),   '-21.9989 != -22 +/- .001');
   ok(!$neg_num->verify(exists => 1, got => -23),        '-23      != -22 +/- .001');
 };
+subtest verify_float_precision => sub {
+  ok($pre_num->verify(exists => 1, got => "22.0"),     '22.0    == 22.000');
+  ok($pre_num->verify(exists => 1, got => "22.0001"),  '22.0001 == 22.000');
+  ok($pre_num->verify(exists => 1, got => "21.9999"),  '21.9999 == 22.000');
+  ok(!$pre_num->verify(exists => 1, got => "22.0011"), '22.0011 != 22.000');
+  ok(!$pre_num->verify(exists => 1, got => "21.9989"), '21.9989 != 22.000');
+  ok(!$pre_num->verify(exists => 1, got => "23"),      '23      != 22.000');
 
-subtest rounding => sub {
+  ok($pre_num->verify(exists => 1, got => 22.0),       '22.0    == 22.000');
+  ok($pre_num->verify(exists => 1, got => 22.00049),    '22.00049 == 22.000');
+  ok(!$pre_num->verify(exists => 1, got => 22.00051),    '22.00051 != 22.000');
+  ok($pre_num->verify(exists => 1, got => 21.99951),   '21.99951 == 22.000');
+  ok(!$pre_num->verify(exists => 1, got => 22.0009),   '22.0009 != 22.000');
+  ok(!$pre_num->verify(exists => 1, got => 21.9989),   '21.9989 != 22.000');
+  ok(!$pre_num->verify(exists => 1, got => 23),        '23      != 22.000');
+
+  ok($neg_num->verify(exists => 1, got => -22.0),       '-22.0    == -22.000');
+  ok($neg_num->verify(exists => 1, got => -22.0009),    '-22.0009 == -22.000');
+  ok($neg_num->verify(exists => 1, got => -21.9991),    '-21.9991 == -22.000');
+  ok(!$neg_num->verify(exists => 1, got => -22.0011),   '-22.0009 != -22.000');
+  ok(!$neg_num->verify(exists => 1, got => -21.9989),   '-21.9989 != -22.000');
+  ok(!$neg_num->verify(exists => 1, got => -23),        '-23      != -22.000');
+};
+
+subtest rounding_tolerance => sub {
     my $round_08    = $CLASS->new(input => '60.48');
     my $round_13    = $CLASS->new(input => '60.48', tolerance => 1e-13);
     my $round_14    = $CLASS->new(input => '60.48', tolerance => 1e-14);
@@ -87,6 +122,22 @@ subtest rounding => sub {
     todo 'broken on some platforms' => sub {
         ok(!$round_14->verify(exists => 1, got => 125 - 64.52), '125 - 64.52 != ' . $round_14->name . " - outside tolerance");
     };
+};
+
+subtest rounding_precision => sub {
+    my $round_08    = $CLASS->new(input => '60.48', precision =>  8 );
+    my $round_13    = $CLASS->new(input => '60.48', precision => 13);
+    my $round_14    = $CLASS->new(input => '60.48', precision => 14);
+
+    ok($round_08->verify(exists => 1, got => 60.48),       '      60.48 == ' . $round_08->name . " - inside precision");
+    ok($round_13->verify(exists => 1, got => 60.48),       '      60.48 == ' . $round_13->name . " - inside precision");
+    ok($round_14->verify(exists => 1, got => 60.48),       '      60.48 == ' . $round_14->name . " - inside precision");
+
+    ok($round_08->verify(exists => 1, got => 125 - 64.52), '125 - 64.52 == ' . $round_08->name . " - inside precision");
+    ok($round_13->verify(exists => 1, got => 125 - 64.52), '125 - 64.52 == ' . $round_13->name . " - inside precision");
+
+    # unlike TOLERANCE, this should work on 32 and 64 bit platforms.
+    ok($round_14->verify(exists => 1, got => 125 - 64.52), '125 - 64.52 != ' . $round_14->name . " - outside precision");
 };
 
 like(
@@ -105,6 +156,22 @@ like(
     dies { $CLASS->new(input => ' ') },
     qr/input must be a number for 'Float' check/,
     "Cannot use whitespace string as a number"
+);
+
+like(
+    dies { $CLASS->new(input => 1.234, precision => 5, tolerance => .001) },
+    qr/can't set both tolerance and precision/,
+    "Cannot use both precision and tolerance"
+);
+like(
+    dies { $CLASS->new(input => 1.234, precision => .05) },
+    qr/precision must be an integer/,
+    "precision can't be fractional"
+);
+like(
+    dies { $CLASS->new(input => 1.234, precision => -2) },
+    qr/precision must be an integer/,
+    "precision can't be negative"
 );
 
 done_testing;

--- a/t/modules/Tools/Compare.t
+++ b/t/modules/Tools/Compare.t
@@ -652,6 +652,10 @@ subtest float => sub {
 
         is($check->tolerance,   1e-08, "default tolerance");
         is($check_3->tolerance, 0.001, "custom tolerance");
+
+        my $check_p3 = float("22.0", precision => 3);
+        is($check_p3->precision,        3, "custom precision");
+        is($check_p3->name,      "22.000", "custom precision name");
     };
 };
 


### PR DESCRIPTION
* `float($float, precision => $pre)` will create a comparison string
  of `$float` with `$pre` digits to the right of decimal point.

* Uses sprintf rounding at a given precision to utilize IEEE 754 rounding
  rules for consistent and reproducible results.
  https://en.wikipedia.org/wiki/Floating-point_arithmetic#Rounding_modes