### PR TITLE
Add rounded() and within() wrappers around approximate comparisons

### DIFF
--- a/lib/Test2/Compare/Float.pm
+++ b/lib/Test2/Compare/Float.pm
@@ -57,6 +57,12 @@ sub operator {
     return '' unless defined($got);
     return '' unless length($got) && $got =~ m/\S/;
 
+    if ( $self->{+PRECISION} )
+    {
+      return 'ne' if $self->{+NEGATE};
+      return 'eq';
+    }
+
     return '!=' if $self->{+NEGATE};
     return '==';
 }

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -65,7 +65,7 @@ our @EXPORT = qw/is like/;
 our @EXPORT_OK = qw{
     is like isnt unlike
     match mismatch validator
-    hash array bag object meta meta_check number float string subset bool
+    hash array bag object meta meta_check number float rounded within string subset bool
     in_set not_in_set check_set
     item field call call_list call_hash prop check all_items all_keys all_vals all_values
     etc end filter_items
@@ -315,6 +315,28 @@ sub float($;@) {
         lines => [$caller[2]],
         input => $num,
         @args,
+    );
+}
+
+sub rounded($$) {
+    my ($num, $precision) = @_;
+    my @caller = caller;
+    return Test2::Compare::Float->new(
+        file      => $caller[1],
+        lines     => [$caller[2]],
+        input     => $num,
+        precision => $precision,
+    );
+}
+
+sub within($;$) {
+    my ($num, $tolerance) = @_;
+    my @caller = caller;
+    return Test2::Compare::Float->new(
+        file      => $caller[1],
+        lines     => [$caller[2]],
+        input     => $num,
+        defined $tolerance ? ( tolerance => $tolerance ) : (),
     );
 }
 
@@ -670,7 +692,7 @@ the field.
     use Test2::Tools::Compare qw{
         is like isnt unlike
         match mismatch validator
-        hash array bag object meta number float string subset bool
+        hash array bag object meta number float rounded within string subset bool
         in_set not_in_set check_set
         item field call call_list call_hash prop check all_items all_keys all_vals all_values
         etc end filter_items
@@ -966,15 +988,50 @@ Verify that the value does not match the given number using the C<!=> operator.
 
 =item $check = float ...;
 
-Verify that the value matches the given float within a +/- tolerance using the C<==> operator.
+Verify that the value is approximately equal to the given number.
 
-Default tolerance is 1e-08 and can be overridden with 'tolerance' parameter.
+If a 'precision' parameter is specified, both operands will be
+rounded to 'precision' number of fractional decimal digits and
+compared with C<eq>.
+
+Otherwise, the check will be made within a range of +/- 'tolerance',
+with a default 'tolerance' of 1e-08.
+
+See also C<within> and C<rounded>.
 
 =item $check = !float ...;
 
-Verify that the value does not match the given float within a +/- tolerance, using the C<!=> operator.
+Verify that the value is not approximately equal to the given number.
 
-Default tolerance is 1e-08 and can be overridden with 'tolerance' parameter.
+If a 'precision' parameter is specified, both operands will be
+rounded to 'precision' number of fractional decimal digits and
+compared with C<eq>.
+
+Otherwise, the check will be made within a range of +/- 'tolerance',
+with a default 'tolerance' of 1e-08.
+
+See also C<!within> and C<!rounded>.
+
+=item $check = within($num, $tolerance);
+
+Verify that the value approximately matches the given number,
+within a range of +/- C<$tolerance>.  Compared using the C<==> operator.
+
+C<$tolerance> is optional and defaults to 1e-08.
+
+=item $check = !within($num, $tolerance);
+
+Verify that the value does not approximately match the given number within a range of +/- C<$tolerance>.  Compared using the C<!=> operator.
+
+C<$tolerance> is optional and defaults to 1e-08.
+
+=item $check = rounded($num, $precision);
+
+Verify that the value approximately matches the given number, when both are rounded to C<$precision> number of fractional digits. Compared using the C<eq> operator.
+
+=item $check = !rounded($num, $precision);
+
+Verify that the value does not approximately match the given number, when both are rounded to C<$precision> number of fractional digits. Compared using the C<ne> operator.
 
 =item $check = bool ...;
 

--- a/lib/Test2/V0.pm
+++ b/lib/Test2/V0.pm
@@ -28,7 +28,7 @@ use Test2::Tools::Basic qw{
 use Test2::Tools::Compare qw{
     is like isnt unlike
     match mismatch validator
-    hash array bag object meta meta_check number float string subset bool
+    hash array bag object meta meta_check number float rounded within string subset bool
     in_set not_in_set check_set
     item field call call_list call_hash prop check all_items all_keys all_vals all_values
     etc end filter_items
@@ -78,7 +78,7 @@ our @EXPORT = qw{
 
     is like isnt unlike
     match mismatch validator
-    hash array bag object meta meta_check number float string subset bool
+    hash array bag object meta meta_check number float rounded within string subset bool
     in_set not_in_set check_set
     item field call call_list call_hash prop check all_items all_keys all_vals all_values
     etc end filter_items

--- a/t/modules/Compare/Float.t
+++ b/t/modules/Compare/Float.t
@@ -38,6 +38,10 @@ subtest operator => sub {
     is($untrue->operator(),      '',   "no operator for 0 + nothing");
     is($untrue->operator(undef), '',   "no operator for 0 + undef");
     is($untrue->operator(1),     '==', "== operator for 0 + number");
+
+    is($pre_num->operator(),      '',   "no operator for precision number + nothing");
+    is($pre_num->operator(undef), '',   "no operator for precision number + undef");
+    is($pre_num->operator(1),     'eq', "eq operator for precision number + number");
 };
 
 subtest verify => sub {

--- a/t/modules/Tools/Compare.t
+++ b/t/modules/Tools/Compare.t
@@ -17,7 +17,7 @@ BEGIN { $ENV{TABLE_TERM_SIZE} = 80 }
 subtest simple => sub {
     imported_ok qw{
         match mismatch validator
-        hash array bag object meta number float string bool
+        hash array bag object meta number float rounded within string bool
         in_set not_in_set check_set
         item field call call_list call_hash prop check all_items all_keys all_vals all_values
         etc end filter_items
@@ -654,6 +654,17 @@ subtest float => sub {
         is($check_3->tolerance, 0.001, "custom tolerance");
 
         my $check_p3 = float("22.0", precision => 3);
+        is($check_p3->precision,        3, "custom precision");
+        is($check_p3->name,      "22.000", "custom precision name");
+    };
+    subtest rounded_and_within => sub {
+        my $check   = within("22.0");
+        my $check_3 = within("22.0", .001);
+
+        is($check->tolerance,   1e-08, "default tolerance");
+        is($check_3->tolerance, 0.001, "custom tolerance");
+
+        my $check_p3 = rounded("22.0", 3);
         is($check_p3->precision,        3, "custom precision");
         is($check_p3->name,      "22.000", "custom precision name");
     };


### PR DESCRIPTION
Adds `rounded()` and `within()` wrappers around the `float()` checks.
