### PR TITLE
spelling fixes in the POD

### DIFF
--- a/lib/Test2/Manual/Anatomy/EndToEnd.pm
+++ b/lib/Test2/Manual/Anatomy/EndToEnd.pm
@@ -40,7 +40,7 @@ still change the formatter, load L<Test2::IPC>, or have other global effects
 that need to be done before the first L<Test2::API::Context> is created. Once
 the first L<Test2::API::Context> is created the API will finish initialization.
 
-See L</"WHAT HAPPENS WHEN I AQUIRE A CONTEXT?"> for more information.
+See L</"WHAT HAPPENS WHEN I ACQUIRE A CONTEXT?"> for more information.
 
 =back
 
@@ -73,11 +73,11 @@ This section covers the basic workflow all tools such as C<ok()> must follow.
 
     my $ctx = context();
 
-See L</"WHAT HAPPENS WHEN I AQUIRE A CONTEXT?"> for more information.
+See L</"WHAT HAPPENS WHEN I ACQUIRE A CONTEXT?"> for more information.
 
 =item The tool uses the context object to create, send, and return events.
 
-See L</"WHAT HAPPEND WHEN I SEND AN EVENT?"> for more information.
+See L</"WHAT HAPPENS WHEN I SEND AN EVENT?"> for more information.
 
     my $event = $ctx->send_event('Ok', pass => $bool, name => $name);
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Test2-Suite.
We thought you might be interested in it too.

    Description: spelling fixes in the POD
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-03-04
    

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
