### PR TITLE
Add ";" to subtest example in POD

### DIFF
--- a/lib/Test2/V0.pm
+++ b/lib/Test2/V0.pm
@@ -451,7 +451,7 @@ See L<Test2::Tools::Subtest>.
 
 =over 4
 
-=item subtest $name => sub { ... }
+=item subtest $name => sub { ... };
 
 (Note: This is called C<subtest_buffered()> in the Tools module.)
 


### PR DESCRIPTION
Just a small alteration to include a ";" at the end of the example for subtest.