### PR TITLE
Fix a warning for note/diag with undefined values

### DIFF
--- a/lib/Test2/Tools/Basic.pm
+++ b/lib/Test2/Tools/Basic.pm
@@ -39,13 +39,13 @@ sub fail {
 
 sub diag {
     my $ctx = context();
-    $ctx->diag( join '', @_ );
+    $ctx->diag( join '', grep { defined $_ } @_ );
     $ctx->release;
 }
 
 sub note {
     my $ctx = context();
-    $ctx->note( join '', @_ );
+    $ctx->note( join '', grep { defined $_ } @_ );
     $ctx->release;
 }
 


### PR DESCRIPTION
When running note or diag with an undefined value it was producing a warning

```
perl -Ilib -E 'use Test2::Tools::Basic; note undef'                                                                                                                           
Use of uninitialized value within @_ in join or string at lib/Test2/Tools/Basic.pm line 48.
#
```