### PR TITLE
sort options keys in import error message

### DIFF
--- a/lib/Test2/V0.pm
+++ b/lib/Test2/V0.pm
@@ -122,7 +122,7 @@ sub import {
     Test2::Tools::Target->import_into($caller, $target)
         if $target;
 
-    croak "Unknown option(s): " . join(', ', keys %options) if keys %options;
+    croak "Unknown option(s): " . join(', ', sort keys %options) if keys %options;
 
     Importer->import_into($class, $caller, @exports);
 }


### PR DESCRIPTION
minor fix to have a consistent error message when using custom options