### PR TITLE
Add support for meta-checks in hash, bag, and array builders

### DIFF
--- a/lib/Test2/Compare/Array.pm
+++ b/lib/Test2/Compare/Array.pm
@@ -6,7 +6,7 @@ use base 'Test2::Compare::Base';
 
 our $VERSION = '0.000119';
 
-use Test2::Util::HashBase qw/inref ending items order for_each/;
+use Test2::Util::HashBase qw/inref meta ending items order for_each/;
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/reftype looks_like_number/;
@@ -42,6 +42,8 @@ sub init {
 
 sub name { '<ARRAY>' }
 
+sub meta_class  { 'Test2::Compare::Meta' }
+
 sub verify {
     my $self = shift;
     my %params = @_;
@@ -52,6 +54,12 @@ sub verify {
     return 0 unless ref($got);
     return 0 unless reftype($got) eq 'ARRAY';
     return 1;
+}
+
+sub add_prop {
+    my $self = shift;
+    $self->{+META} = $self->meta_class->new unless defined $self->{+META};
+    $self->{+META}->add_prop(@_);
 }
 
 sub top_index {
@@ -108,6 +116,9 @@ sub deltas {
     my @order = @{$self->{+ORDER}};
     my $items = $self->{+ITEMS};
     my $for_each = $self->{+FOR_EACH};
+
+    my $meta     = $self->{+META};
+    push @deltas => $meta->deltas(%params) if defined $meta;
 
     # Make a copy that we can munge as needed.
     my @list = @$got;

--- a/lib/Test2/Compare/Bag.pm
+++ b/lib/Test2/Compare/Bag.pm
@@ -6,7 +6,7 @@ use base 'Test2::Compare::Base';
 
 our $VERSION = '0.000119';
 
-use Test2::Util::HashBase qw/ending items/;
+use Test2::Util::HashBase qw/ending meta items/;
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/reftype looks_like_number/;
@@ -21,6 +21,8 @@ sub init {
 
 sub name { '<BAG>' }
 
+sub meta_class  { 'Test2::Compare::Meta' }
+
 sub verify {
     my $self = shift;
     my %params = @_;
@@ -30,6 +32,12 @@ sub verify {
     return 0 unless ref($got);
     return 0 unless reftype($got) eq 'ARRAY';
     return 1;
+}
+
+sub add_prop {
+    my $self = shift;
+    $self->{+META} = $self->meta_class->new unless defined $self->{+META};
+    $self->{+META}->add_prop(@_);
 }
 
 sub add_item {
@@ -52,6 +60,9 @@ sub deltas {
     # Make a copy that we can munge as needed.
     my @list = @$got;
     my %unmatched = map { $_ => $list[$_] } 0..$#list;
+
+    my $meta     = $self->{+META};
+    push @deltas => $meta->deltas(%params) if defined $meta;
 
     while (@items) {
         my $item = shift @items;

--- a/lib/Test2/Compare/Hash.pm
+++ b/lib/Test2/Compare/Hash.pm
@@ -6,7 +6,7 @@ use base 'Test2::Compare::Base';
 
 our $VERSION = '0.000119';
 
-use Test2::Util::HashBase qw/inref ending items order for_each_key for_each_val/;
+use Test2::Util::HashBase qw/inref meta ending items order for_each_key for_each_val/;
 
 use Carp qw/croak confess/;
 use Scalar::Util qw/reftype/;
@@ -43,6 +43,8 @@ sub init {
 
 sub name { '<HASH>' }
 
+sub meta_class  { 'Test2::Compare::Meta' }
+
 sub verify {
     my $self = shift;
     my %params = @_;
@@ -53,6 +55,12 @@ sub verify {
     return 0 unless ref($got);
     return 0 unless reftype($got) eq 'HASH';
     return 1;
+}
+
+sub add_prop {
+    my $self = shift;
+    $self->{+META} = $self->meta_class->new unless defined $self->{+META};
+    $self->{+META}->add_prop(@_);
 }
 
 sub add_field {
@@ -91,6 +99,9 @@ sub deltas {
 
     # Make a copy that we can munge as needed.
     my %fields = %$got;
+
+    my $meta     = $self->{+META};
+    push @deltas => $meta->deltas(%params) if defined $meta;
 
     for my $key (@{$self->{+ORDER}}) {
         my $check  = $convert->($items->{$key});

--- a/t/modules/Compare/Array.t
+++ b/t/modules/Compare/Array.t
@@ -251,5 +251,16 @@ subtest objects_as_arrays => sub {
     is ( $o1, $o2, "same" );
 };
 
+subtest add_prop => sub {
+    my $one = $CLASS->new();
+
+    ok(!$one->meta, "no meta yet");
+    $one->add_prop('size' => 1);
+    isa_ok($one->meta, 'Test2::Compare::Meta');
+    is(@{$one->meta->items}, 1, "1 item");
+
+    $one->add_prop('reftype' => 'ARRAY');
+    is(@{$one->meta->items}, 2, "2 items");
+};
 
 done_testing;

--- a/t/modules/Compare/Bag.t
+++ b/t/modules/Compare/Bag.t
@@ -149,4 +149,16 @@ subtest deltas => sub {
     };
 };
 
+subtest add_prop => sub {
+    my $one = $CLASS->new();
+
+    ok(!$one->meta, "no meta yet");
+    $one->add_prop('size' => 1);
+    isa_ok($one->meta, 'Test2::Compare::Meta');
+    is(@{$one->meta->items}, 1, "1 item");
+
+    $one->add_prop('reftype' => 'ARRAY');
+    is(@{$one->meta->items}, 2, "2 items");
+};
+
 done_testing;

--- a/t/modules/Compare/Hash.t
+++ b/t/modules/Compare/Hash.t
@@ -180,6 +180,18 @@ subtest deltas => sub {
 
 };
 
+subtest add_prop => sub {
+    my $one = $CLASS->new();
+
+    ok(!$one->meta, "no meta yet");
+    $one->add_prop('size' => 1);
+    isa_ok($one->meta, 'Test2::Compare::Meta');
+    is(@{$one->meta->items}, 1, "1 item");
+
+    $one->add_prop('reftype' => 'HASH');
+    is(@{$one->meta->items}, 2, "2 items");
+};
+
 {
   package Foo::Hash;
 

--- a/t/modules/Tools/Compare.t
+++ b/t/modules/Tools/Compare.t
@@ -962,10 +962,37 @@ subtest prop => sub {
         "restricted context"
     );
 
-    like(
-        dies { [array { prop x => 1 }] },
-        qr/'Test2::Compare::Array.*' does not support meta-checks/,
-        "not everything supports properties"
+    is(
+        [1],
+        array { prop size => 1; etc; },
+        "Array builder supports 'prop'"
+    );
+
+    is(
+        [1],
+        bag { prop size => 1; etc; },
+        "Bag builder supports 'prop'"
+    );
+
+    is(
+        { foo => 1, },
+        hash { prop size => 1; etc; },
+        "Hash builder supports 'prop'"
+    );
+
+    my $events = intercept {
+        is( [1],           array { prop size => 2; etc; } );
+        is( [1],           bag   { prop size => 2; etc; } );
+        is( { foo => 1, }, hash  { prop size => 2; etc; } );
+    };
+
+    is(
+        $events,
+        array {
+            filter_items { grep { ref =~ /::Ok/ } @_ };
+            all_items object { call pass => F };
+            etc;
+        }
     );
 };
 


### PR DESCRIPTION
This is an attempt at addressing the issue in #131.

I'm not sure if this is a desired feature or not, since the issue has been around since 2017 and is still open with no comments. But I agree with the poster in that it seems like something that should be possible, and it certainly seems clearer to write

``` perl
is [1], array { prop size => 1; etc; };
```

than

``` perl
is [1], array { item 0 => E; item 1 => DNE; end; };
```
