### PR TITLE
Rename example variable in Bag documentation

### DIFF
--- a/lib/Test2/Compare/Bag.pm
+++ b/lib/Test2/Compare/Bag.pm
@@ -147,7 +147,7 @@ more items than the check. That is, if you check for 4 items but the array has
 unexpected. If set to false then it is assumed you do not care about extra
 items.
 
-=item $hashref = $arr->items()
+=item $arrayref = $arr->items()
 
 Returns the arrayref of values to be checked in the array.
 


### PR DESCRIPTION
It used to be `$hashref`, but the method it was documenting actually returns an array reference