### PR TITLE
Add all_items support in Bag

### DIFF
--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -1332,6 +1332,11 @@ check object.
 B<Note:> This function can only be used inside an array, bag or subset
 builder sub, and must be called in void context.
 
+=item all_items($CHECK1, $CHECK2, ...)
+
+Add checks that apply to all items. You can put this anywhere in the bag
+block, and can call it any number of times with any number of arguments.
+
 =item end()
 
 Enforce that there are no more items after the last one specified.


### PR DESCRIPTION
This patch adds support for `all_items` in bag builders.

Like with #177, this is the result of reaching for a feature and realising after the fact that it wasn't supported.

There are work-arounds to not having this, like 

```perl
is \@array, meta {
    prop this => array { all_items $check; etc };
    prop this => bag { ... };
};
```

but that feels overly verbose, and I'm not clear on the rationale for not supporting this feature.

If there is a reason for this that I'm missing, we might want to add that to the docs and close this instead.