### PR TITLE
Allow hashref to be used for Test2::Tools::Target

### DIFF
--- a/lib/Test2/Bundle/Extended.pm
+++ b/lib/Test2/Bundle/Extended.pm
@@ -191,8 +191,8 @@ Or you can specify names:
 
     use Test2::Bundle::Extended -target => { pkg => 'Some::Package' };
 
-    PKG()->xxx; # Call 'xxx' on Some::Package
-    $PKG->xxx;  # Same
+    pkg()->xxx; # Call 'xxx' on Some::Package
+    $pkg->xxx;  # Same
 
 =over 4
 

--- a/lib/Test2/Bundle/Extended.pm
+++ b/lib/Test2/Bundle/Extended.pm
@@ -187,6 +187,13 @@ not provide a target then C<$CLASS> and C<CLASS()> will not be imported.
     print $CLASS;  # My::Class
     print CLASS(); # My::Class
 
+Or you can specify names:
+
+    use Test2::Bundle::Extended -target => { pkg => 'Some::Package' };
+
+    PKG()->xxx; # Call 'xxx' on Some::Package
+    $PKG->xxx;  # Same
+
 =over 4
 
 =item $CLASS

--- a/lib/Test2/Tools/Target.pm
+++ b/lib/Test2/Tools/Target.pm
@@ -82,8 +82,8 @@ Or you can specify names:
 
     use Test2::Tools::Target pkg => 'Some::Package';
 
-    PKG()->xxx; # Call 'xxx' on Some::Package
-    $PKG->xxx;  # Same
+    pkg()->xxx; # Call 'xxx' on Some::Package
+    $pkg->xxx;  # Same
 
 =head1 SOURCE
 

--- a/lib/Test2/Tools/Target.pm
+++ b/lib/Test2/Tools/Target.pm
@@ -23,7 +23,12 @@ sub import_into {
 
     my %targets;
     if (@_ == 1) {
-        ($targets{CLASS}) = @_;
+        if (ref $_[0] eq 'HASH') {
+            %targets = %{ $_[0] };
+        }
+        else {
+            ($targets{CLASS}) = @_;
+        }
     }
     else {
         %targets = @_;

--- a/lib/Test2/V0.pm
+++ b/lib/Test2/V0.pm
@@ -304,8 +304,8 @@ Or you can specify names:
 
     use Test2::V0 -target => { pkg => 'Some::Package' };
 
-    PKG()->xxx; # Call 'xxx' on Some::Package
-    $PKG->xxx;  # Same
+    pkg()->xxx; # Call 'xxx' on Some::Package
+    $pkg->xxx;  # Same
 
 =over 4
 

--- a/lib/Test2/V0.pm
+++ b/lib/Test2/V0.pm
@@ -300,6 +300,13 @@ not provide a target then C<$CLASS> and C<CLASS()> will not be imported.
     print $CLASS;  # My::Class
     print CLASS(); # My::Class
 
+Or you can specify names:
+
+    use Test2::V0 -target => { pkg => 'Some::Package' };
+
+    PKG()->xxx; # Call 'xxx' on Some::Package
+    $PKG->xxx;  # Same
+
 =over 4
 
 =item $CLASS


### PR DESCRIPTION
It looks as if you cannot specify names via `Test2::V0 -target => ...` like you can in `Test2::Tools::Target`. This change is to allow for a hashref to be given
e.g. `Test2::V0 -target => { pkg => 'My::App' };`