### PR TITLE
Improve error handling of mock->override with AUTOLOADed methods

### DIFF
--- a/lib/Test2/Mock.pm
+++ b/lib/Test2/Mock.pm
@@ -197,13 +197,14 @@ EOT
     $line = __LINE__ + 3;
     my $can = eval <<EOT || die "Failed generating can method: $@";
 package $class;
+use Scalar::Util 'reftype';
 #line $line "$file (Generated can)"
     sub {
         my (\$self, \$meth) = \@_;
         if (\$self->SUPER::can(\$meth)) {
             return \$self->SUPER::can(\$meth);
         }
-        elsif (exists \$self->{\$meth}) {
+        elsif (ref \$self && reftype \$self eq 'HASH' && exists \$self->{\$meth}) {
             return sub { shift->\$meth(\@_) };
         }
         return undef;

--- a/t/modules/Mock.t
+++ b/t/modules/Mock.t
@@ -782,6 +782,17 @@ subtest exceptions => sub {
         qr/Symbol '&foo' is not mocked/,
         "did not mock foo"
     );
+
+    my $bare = Test2::Mock->new(
+        class => 'Fake17',
+        autoload => 1,
+    );
+
+    like(
+        dies { $bare->override( missing => 1 ) },
+        qr/Cannot override '&Fake17::missing', symbol is not already defined/,
+        "Cannot override a method that is not defined in an AUTOLOAD mock"
+    );
 };
 
 subtest override_inherited_method => sub {


### PR DESCRIPTION
Before this patch, calling `override` on a mock object that had not set a particular method would die with a seemingly unrelated and uninformative error. The following code:

```
$ perl -Ilib -MTest2::V0 -E '
    my $mock = mock; 
    my ($control) = mocked $mock; 
    $control->override( foo => 1 );
'
```

would result in the following error message:

```
Can't use string ("Test2::Tools::Mock::__TEMP__::AS"...) as a HASH ref while "strict refs" in use at lib/Test2/Mock.pm (Generated can) line 205.
```

This patch makes it so that it now dies with the following:

```
Cannot override '&Test2::Tools::Mock::__TEMP__::ASLPEMLYOANIQEXWKGQYJRSAFFZQVEFP::foo', symbol is not already defined at -e line 1.
```