### PR TITLE
Fix synopsis for Test2::Tools::AsyncSubtest

### DIFF
--- a/lib/Test2/Tools/AsyncSubtest.pm
+++ b/lib/Test2/Tools/AsyncSubtest.pm
@@ -101,7 +101,6 @@ other events are also being generated.
     # any child processes and threads.
     $ast1->finish;
     $ast2->finish;
-    $ast3->finish;
 
     done_testing;
 


### PR DESCRIPTION
before removing this line the test doesn't compile since Test2::Bundle::Extended makes the script strict.