### PR TITLE
Fixed - missing optional @diag in Test2::V0 master doc

### DIFF
--- a/lib/Test2/V0.pm
+++ b/lib/Test2/V0.pm
@@ -337,11 +337,11 @@ See L<Test2::Tools::Basic>.
 
 =over 4
 
-=item ok($bool, $name)
+=item ok($bool, $name, @diag)
 
-=item pass($name)
+=item pass($name, @diag)
 
-=item fail($name)
+=item fail($name, @diag)
 
 =item diag($message)
 


### PR DESCRIPTION
Fixes: https://metacpan.org/pod/Test2::V0#BASIC shows the prototype for `ok`, `pass`, and `fail`, without their optional diagnostics.

