### PR TITLE
Offer way to supply random seed at `use` time (GitHub issue #193)

### DIFF
--- a/lib/Test2/Plugin/SRand.pm
+++ b/lib/Test2/Plugin/SRand.pm
@@ -26,8 +26,12 @@ sub import {
     carp "SRand loaded multiple times, re-seeding rand"
         if defined $SEED;
 
-    if (@_) {
+    if (@_ == 1) {
         ($SEED) = @_;
+        $FROM = 'import arg';
+    }
+    elsif (@_ == 2 and $_[0] eq 'seed') {
+        $SEED = $_[1];
         $FROM = 'import arg';
     }
     elsif(exists $ENV{T2_RAND_SEED}) {
@@ -115,7 +119,7 @@ Loading the plugin is easy, and the defaults are sane:
 
 Custom seed:
 
-    use Test2::Plugin::SRand 42;
+    use Test2::Plugin::SRand seed => 42;
 
 =head1 NOTE ON LOAD ORDER
 


### PR DESCRIPTION
The previously documented way failed, thwarted by Perl thinking the seed
is a minimum version requirement for the module:

$ perl -e 'use Test2::Plugin::SRand 42;'
Test2::Plugin::SRand version 42 required--this is only version 0.000126 at -e line 1.
BEGIN failed--compilation aborted at -e line 1

Now can do:

use Test2::Plugin::SRand seed => 42;

This remains backward-compatible with the old interface that works like:

Test2::Plugin::SRand->import(42);