### PR TITLE
Remove defined-or operator for Perl 5.8 support

### DIFF
--- a/lib/Test2/AsyncSubtest.pm
+++ b/lib/Test2/AsyncSubtest.pm
@@ -265,7 +265,7 @@ sub start {
     croak "Subtest is already complete"
         if $self->{+FINISHED};
 
-    $self->{+START_STAMP} //= time;
+    $self->{+START_STAMP} = time unless defined $self->{+START_STAMP};
 
     $self->{+ACTIVE}++;
 
@@ -312,7 +312,8 @@ sub finish {
         if $self->{+ACTIVE};
 
     $self->wait;
-    my $stop_stamp = $self->{+STOP_STAMP} //= time;
+    $self->{+STOP_STAMP} = time unless defined $self->{+STOP_STAMP};
+    my $stop_stamp = $self->{+STOP_STAMP};
 
     my $todo       = $params{todo};
     my $skip       = $params{skip};


### PR DESCRIPTION
This fixes #236 by adjusting some of the changes introduced in 6f63efdfb93d8388e13501b468f02b93a98e6867