### PR TITLE
Fix diagnostic rendering in deprecation warning

### DIFF
--- a/lib/Test2/Tools/ClassicCompare.pm
+++ b/lib/Test2/Tools/ClassicCompare.pm
@@ -168,7 +168,7 @@ sub is_deeply($$;$@) {
                 "The exising behavior is to default to etc() when inside is_deeply().",
                 "The new behavior is to default to end().",
                 "This test will soon start to fail with the following diagnostics:",
-                $delta->diag,
+                $delta->diag->as_string,
                 "",
             );
         }

--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -108,7 +108,7 @@ sub is($$;$@) {
                 "The old behavior was a bug.",
                 "The new behavior is to default to end().",
                 "This test will soon start to fail with the following diagnostics:",
-                $delta->diag,
+                $delta->diag->as_string,
                 "",
             );
         }


### PR DESCRIPTION
When running something like

    $ perl -Ilib -MTest2::V0 -E 'is [1], array {1}; done_testing'

the test passes with the following warning message

    ok 1
    !!! NOTICE OF BEHAVIOR CHANGE !!!
    This test uses at least 1 <ARRAY> check without using end() or etc().
    The old behavior was to default to etc() when inside is().
    The old behavior was a bug.
    The new behavior is to default to end().
    This test will soon start to fail with the following diagnostics:
    Test2::EventFacet::Info::Table=HASH(0x55f65d07b250)
     at -e line 1.

The final stringifies the Test2::EventFacet::Info::Table directly,
without rendering it, which does not provide a useful diagnostic.

This patch fixes that by calling ->as_string on the table.