### PR TITLE
Add stringify_got parameter to Test2::Compare::Custom

### DIFF
--- a/lib/Test2/Compare/Custom.pm
+++ b/lib/Test2/Compare/Custom.pm
@@ -6,7 +6,7 @@ use base 'Test2::Compare::Base';
 
 our $VERSION = '0.000143';
 
-use Test2::Util::HashBase qw/code name operator/;
+use Test2::Util::HashBase qw/code name operator stringify_got/;
 
 use Carp qw/croak/;
 
@@ -17,6 +17,8 @@ sub init {
 
     $self->{+OPERATOR} ||= 'CODE(...)';
     $self->{+NAME}     ||= '<Custom Code>';
+    $self->{+STRINGIFY_GOT} = $self->SUPER::stringify_got()
+      unless defined $self->{+STRINGIFY_GOT};
 
     $self->SUPER::init();
 }
@@ -63,6 +65,7 @@ provides a way for you to write custom checks for fields in deep comparisons.
     my $cus = Test2::Compare::Custom->new(
         name => 'IsRef',
         operator => 'ref(...)',
+        stringify_got => 1,
         code => sub {
             my %args = @_;
             return $args{got} ? 1 : 0;
@@ -136,6 +139,10 @@ Returns the name provided at construction.
 
 Returns the operator provided at construction.
 
+=item $stringify = $cus->stringify_got
+
+Returns the stringify_got flag provided at construction.
+
 =item $bool = $cus->verify(got => $got, exists => $bool)
 
 =back
@@ -158,6 +165,8 @@ F<https://github.com/Test-More/Test2-Suite/>.
 =over 4
 
 =item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Daniel Böhmer E<lt>dboehmer@cpan.orgE<gt>
 
 =back
 

--- a/t/modules/Compare/Custom.t
+++ b/t/modules/Compare/Custom.t
@@ -1,4 +1,5 @@
 use Test2::Bundle::Extended -target => 'Test2::Compare::Custom';
+use Test2::API qw(intercept);
 
 my $pass = $CLASS->new(code => sub { 1 });
 my $fail = $CLASS->new(code => sub { 0 });
@@ -11,6 +12,33 @@ ok(!$fail->verify(got => "anything"), "always fails");
 
 is($pass->operator, 'CODE(...)', "default operator");
 is($pass->name, '<Custom Code>', "default name");
+ok(!$pass->stringify_got, "default stringify_got");
+
+{
+    package My::String;
+    use overload '""' => sub { "xxx" };
+}
+
+my $stringify = $CLASS->new(code => sub { 0 }, stringify_got => 1);
+ok($stringify->stringify_got, "custom stringify_got()");
+like(
+    intercept {
+        my $object = bless {}, 'My::String';
+        is($object => $stringify);
+    },
+    array {
+        event Fail => sub {
+            call info => array {
+                item hash {
+                    field table => hash {
+                        field rows => [['', '', 'xxx', 'CODE(...)', '<Custom Code>']];
+                    };
+                };
+            };
+        };
+    },
+    "stringified object in test output"
+);
 
 my $args;
 my $under;


### PR DESCRIPTION
Solves #239.

- used `//` instead of `unless`-construct like ceca685600d3bf6e8d1f599f834ecdf0fcd043e2
- tried not to make arbitrary assumptions but use `$self->SUPER::stringify_got()` as the default value
- including POD and basic test
- added myself to authors list in module