### PR TITLE
Warn for dies() and lives() in void context

### DIFF
--- a/lib/Test2/Tools/Exception.pm
+++ b/lib/Test2/Tools/Exception.pm
@@ -4,6 +4,7 @@ use warnings;
 
 our $VERSION = '0.000144';
 
+use Carp qw/carp/;
 use Test2::API qw/context/;
 
 our @EXPORT = qw/dies lives try_ok/;
@@ -11,6 +12,9 @@ use base 'Exporter';
 
 sub dies(&) {
     my $code = shift;
+
+    defined wantarray or carp "Useless use of dies() in void context";
+
     local ($@, $!, $?);
     my $ok = eval { $code->(); 1 };
     my $err = $@;
@@ -28,6 +32,8 @@ sub dies(&) {
 
 sub lives(&) {
     my $code = shift;
+
+    defined wantarray or carp "Useless use of lives() in void context";
 
     my $err;
     {

--- a/t/modules/Tools/Exception.t
+++ b/t/modules/Tools/Exception.t
@@ -42,4 +42,16 @@ is(
 
 like($err, qr/abc/, '$@ has the exception');
 
+like(
+    warning { dies { 1 } },
+    qr/Useless use of dies\(\) in void context/,
+    "warns in void context"
+);
+
+like(
+    warning { lives { 1 } },
+    qr/Useless use of lives\(\) in void context/,
+    "warns in void context"
+);
+
 done_testing;


### PR DESCRIPTION
Closes #243.

* also implemented for `lives()`
* not sure if `Carp::carp()` is right or context object must be utilized?
* message similar to 

```console
$ perl -we 'abs $$'
Useless use of abs in void context at -e line 1.
```

but with parens to indicate method name