### PR TITLE
Add modules Test2::Require::(Automated|Extended|NonInteractive|Release)Testing

### DIFF
--- a/lib/Test2/Require/AutomatedTesting.pm
+++ b/lib/Test2/Require/AutomatedTesting.pm
@@ -1,0 +1,72 @@
+package Test2::Require::AutomatedTesting;
+use strict;
+use warnings;
+
+use base 'Test2::Require';
+
+our $VERSION = '0.000156';
+
+sub skip {
+    my $class = shift;
+    return undef if $ENV{'AUTOMATED_TESTING'};
+    return 'Automated test, set the $AUTOMATED_TESTING environment variable to run it';
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Test2::Require::AutomatedTesting - Only run a test when the AUTOMATED_TESTING
+environment variable is set.
+
+=head1 DESCRIPTION
+
+It is common practice to write tests that are only run when the AUTOMATED_TESTING
+environment variable is set. This module automates the (admittedly trivial) work
+of creating such a test.
+
+=head1 SYNOPSIS
+
+    use Test2::Require::AutomatedTesting;
+
+    ...
+
+    done_testing;
+
+=head1 SOURCE
+
+The source code repository for Test2-Suite can be found at
+F<https://github.com/Test-More/Test2-Suite/>.
+
+=head1 MAINTAINERS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 AUTHORS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright 2018 Chad Granum E<lt>exodist@cpan.orgE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See F<http://dev.perl.org/licenses/>
+
+=cut

--- a/lib/Test2/Require/ExtendedTesting.pm
+++ b/lib/Test2/Require/ExtendedTesting.pm
@@ -1,0 +1,72 @@
+package Test2::Require::ExtendedTesting;
+use strict;
+use warnings;
+
+use base 'Test2::Require';
+
+our $VERSION = '0.000156';
+
+sub skip {
+    my $class = shift;
+    return undef if $ENV{'EXTENDED_TESTING'};
+    return 'Extended test, set the $EXTENDED_TESTING environment variable to run it';
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Test2::Require::ExtendedTesting - Only run a test when the EXTENDED_TESTING
+environment variable is set.
+
+=head1 DESCRIPTION
+
+It is common practice to write tests that are only run when the EXTENDED_TESTING
+environment variable is set. This module automates the (admittedly trivial) work
+of creating such a test.
+
+=head1 SYNOPSIS
+
+    use Test2::Require::ExtendedTesting;
+
+    ...
+
+    done_testing;
+
+=head1 SOURCE
+
+The source code repository for Test2-Suite can be found at
+F<https://github.com/Test-More/Test2-Suite/>.
+
+=head1 MAINTAINERS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 AUTHORS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright 2018 Chad Granum E<lt>exodist@cpan.orgE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See F<http://dev.perl.org/licenses/>
+
+=cut

--- a/lib/Test2/Require/NonInteractiveTesting.pm
+++ b/lib/Test2/Require/NonInteractiveTesting.pm
@@ -1,0 +1,72 @@
+package Test2::Require::NonInteractiveTesting;
+use strict;
+use warnings;
+
+use base 'Test2::Require';
+
+our $VERSION = '0.000156';
+
+sub skip {
+    my $class = shift;
+    return undef if $ENV{'NONINTERACTIVE_TESTING'};
+    return 'NonInteractive test, set the $NONINTERACTIVE_TESTING environment variable to run it';
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Test2::Require::NonInteractiveTesting - Only run a test when the NONINTERACTIVE_TESTING
+environment variable is set.
+
+=head1 DESCRIPTION
+
+It is common practice to write tests that are only run when the NONINTERACTIVE_TESTING
+environment variable is set. This module automates the (admittedly trivial) work
+of creating such a test.
+
+=head1 SYNOPSIS
+
+    use Test2::Require::NonInteractiveTesting;
+
+    ...
+
+    done_testing;
+
+=head1 SOURCE
+
+The source code repository for Test2-Suite can be found at
+F<https://github.com/Test-More/Test2-Suite/>.
+
+=head1 MAINTAINERS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 AUTHORS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright 2018 Chad Granum E<lt>exodist@cpan.orgE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See F<http://dev.perl.org/licenses/>
+
+=cut

--- a/lib/Test2/Require/ReleaseTesting.pm
+++ b/lib/Test2/Require/ReleaseTesting.pm
@@ -1,0 +1,72 @@
+package Test2::Require::ReleaseTesting;
+use strict;
+use warnings;
+
+use base 'Test2::Require';
+
+our $VERSION = '0.000156';
+
+sub skip {
+    my $class = shift;
+    return undef if $ENV{'RELEASE_TESTING'};
+    return 'Release test, set the $RELEASE_TESTING environment variable to run it';
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Test2::Require::ReleaseTesting - Only run a test when the RELEASE_TESTING
+environment variable is set.
+
+=head1 DESCRIPTION
+
+It is common practice to write tests that are only run when the RELEASE_TESTING
+environment variable is set. This module automates the (admittedly trivial) work
+of creating such a test.
+
+=head1 SYNOPSIS
+
+    use Test2::Require::ReleaseTesting;
+
+    ...
+
+    done_testing;
+
+=head1 SOURCE
+
+The source code repository for Test2-Suite can be found at
+F<https://github.com/Test-More/Test2-Suite/>.
+
+=head1 MAINTAINERS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 AUTHORS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright 2018 Chad Granum E<lt>exodist@cpan.orgE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See F<http://dev.perl.org/licenses/>
+
+=cut

--- a/t/modules/Require/AutomatedTesting.t
+++ b/t/modules/Require/AutomatedTesting.t
@@ -1,0 +1,12 @@
+use Test2::Bundle::Extended -target => 'Test2::Require::AutomatedTesting';
+
+{
+    local %ENV = %ENV;
+    $ENV{AUTOMATED_TESTING} = 0;
+    is($CLASS->skip(), 'Automated test, set the $AUTOMATED_TESTING environment variable to run it', "will skip");
+
+    $ENV{AUTOMATED_TESTING} = 1;
+    is($CLASS->skip(), undef, "will not skip");
+}
+
+done_testing;

--- a/t/modules/Require/ExtendedTesting.t
+++ b/t/modules/Require/ExtendedTesting.t
@@ -1,0 +1,12 @@
+use Test2::Bundle::Extended -target => 'Test2::Require::ExtendedTesting';
+
+{
+    local %ENV = %ENV;
+    $ENV{EXTENDED_TESTING} = 0;
+    is($CLASS->skip(), 'Extended test, set the $EXTENDED_TESTING environment variable to run it', "will skip");
+
+    $ENV{EXTENDED_TESTING} = 1;
+    is($CLASS->skip(), undef, "will not skip");
+}
+
+done_testing;

--- a/t/modules/Require/NonInteractiveTesting.t
+++ b/t/modules/Require/NonInteractiveTesting.t
@@ -1,0 +1,12 @@
+use Test2::Bundle::Extended -target => 'Test2::Require::NonInteractiveTesting';
+
+{
+    local %ENV = %ENV;
+    $ENV{NONINTERACTIVE_TESTING} = 0;
+    is($CLASS->skip(), 'NonInteractive test, set the $NONINTERACTIVE_TESTING environment variable to run it', "will skip");
+
+    $ENV{NONINTERACTIVE_TESTING} = 1;
+    is($CLASS->skip(), undef, "will not skip");
+}
+
+done_testing;

--- a/t/modules/Require/ReleaseTesting.t
+++ b/t/modules/Require/ReleaseTesting.t
@@ -1,0 +1,12 @@
+use Test2::Bundle::Extended -target => 'Test2::Require::ReleaseTesting';
+
+{
+    local %ENV = %ENV;
+    $ENV{RELEASE_TESTING} = 0;
+    is($CLASS->skip(), 'Release test, set the $RELEASE_TESTING environment variable to run it', "will skip");
+
+    $ENV{RELEASE_TESTING} = 1;
+    is($CLASS->skip(), undef, "will not skip");
+}
+
+done_testing;


### PR DESCRIPTION
The [Lancaster Consensus](https://github.com/Perl-Toolchain-Gang/toolchain-site/blob/master/lancaster-consensus.md#environment-variables-for-testing-contexts#environment-variables-for-testing-contexts) defines five
environment variables for context:

    * AUTOMATED_TESTING
    * NONINTERACTIVE_TESTING
    * EXTENDED_TESTING
    * RELEASE_TESTING
    * AUTHOR_TESTING

Only AUTHOR_TESTING is supported by module `Test2::Require::AuthorTesting`.
This pull request will add support for the remaining four.