### PR TITLE
Get Test2 tests working on VMS

### DIFF
--- a/t/modules/Plugin/SRand.t
+++ b/t/modules/Plugin/SRand.t
@@ -33,9 +33,8 @@ sub intercept_2(&) {
 }
 
 {
-    local %ENV = %ENV;
-    $ENV{HARNESS_IS_VERBOSE} = 1;
-    $ENV{T2_RAND_SEED} = 1234;
+    local $ENV{HARNESS_IS_VERBOSE} = 1;
+    local $ENV{T2_RAND_SEED} = 1234;
 
     my ($events, $warning);
     my $reseed_qr = qr/SRand loaded multiple times, re-seeding rand/;

--- a/t/modules/Require/AuthorTesting.t
+++ b/t/modules/Require/AuthorTesting.t
@@ -1,8 +1,7 @@
 use Test2::Bundle::Extended -target => 'Test2::Require::AuthorTesting';
 
 {
-    local %ENV = %ENV;
-    $ENV{AUTHOR_TESTING} = 0;
+    local $ENV{AUTHOR_TESTING} = 0;
     is($CLASS->skip(), 'Author test, set the $AUTHOR_TESTING environment variable to run it', "will skip");
 
     $ENV{AUTHOR_TESTING} = 1;

--- a/t/modules/Require/EnvVar.t
+++ b/t/modules/Require/EnvVar.t
@@ -1,8 +1,7 @@
 use Test2::Bundle::Extended -target => 'Test2::Require::EnvVar';
 
 {
-    local %ENV = %ENV;
-    $ENV{FOO} = 0;
+    local $ENV{FOO} = 0;
     is($CLASS->skip('FOO'), 'This test only runs if the $FOO environment variable is set', "will skip");
 
     $ENV{FOO} = 1;

--- a/t/modules/Tools/GenTemp.t
+++ b/t/modules/Tools/GenTemp.t
@@ -24,12 +24,12 @@ ok($tmp, "Got a temp dir ($tmp)");
 
 ok(-d File::Spec->canonpath($_), "Created dir $_") for (
     $tmp,
-    "$tmp/subdir",
-    "$tmp/subdir/nested",
+    File::Spec->catdir($tmp, 'subdir'),
+    File::Spec->catdir($tmp, 'subdir', 'nested'),
 );
 
 for my $file (qw{foo bar subdir/baz subdir/nested/bat}) {
-    my $cp = File::Spec->canonpath("$tmp/$file");
+    my $cp = File::Spec->catfile($tmp, $file);
     ok(-f $cp, "Created file $file");
     open(my $fh, '<', $cp) or die "Could not open file '$cp': $!";
     my $content = $file;


### PR DESCRIPTION
List assignment to %ENV is not supported, and mongrel filenames produced by concatenating hard-coded slashes with the return values from File::Spec functions don't work.