### PR TITLE
Document that diag() returns false,

### DIFF
--- a/lib/Test2/Tools/Basic.pm
+++ b/lib/Test2/Tools/Basic.pm
@@ -41,6 +41,7 @@ sub diag {
     my $ctx = context();
     $ctx->diag( join '', grep { defined $_ } @_ );
     $ctx->release;
+    return 0;
 }
 
 sub note {
@@ -247,6 +248,8 @@ Fire off a failing test (a single Ok event). The name and diagnostics are option
 
 Write diagnostics messages. All items in C<@messages> will be joined into a
 single string with no separator. When using TAP, diagnostics are sent to STDERR.
+
+Returns false, so as to preserve failure.
 
 =item note(@messages)
 


### PR DESCRIPTION
and add 'return 0;' at its end as defensive programming (a.k.a. paranoia).