### PR TITLE
Correction to minor spelling error, mentioned in comment in Test::More repository

### DIFF
--- a/lib/Test2/Tools/Compare.pm
+++ b/lib/Test2/Tools/Compare.pm
@@ -1778,7 +1778,7 @@ Check for details about the event:
         # Check the file the event reports to
         prop file => 'foo.t';
 
-        # Check the line number the event reports o
+        # Check the line number the event reports to
         prop line => '42';
 
         # You can check the todo/skip values as well:


### PR DESCRIPTION
Corrected minor spelling error mentioned in: 

- https://github.com/Test-More/test-more/issues/860#issuecomment-653584254