### PR TITLE
Fix NAME of Test2::Manual::Anatomy::EndToEnd

### DIFF
--- a/lib/Test2/Manual/Anatomy/EndToEnd.pm
+++ b/lib/Test2/Manual/Anatomy/EndToEnd.pm
@@ -10,7 +10,7 @@ __END__
 
 =head1 NAME
 
-Test2::Manual::EndToEnd - Overview of Test2 from load to finish.
+Test2::Manual::Anatomy::EndToEnd - Overview of Test2 from load to finish.
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
discovered as perldoc.perl.org thinks the Test2::Manual::EndToEnd documentation is missing.