### PR TITLE
Some test portability fixes

### DIFF
--- a/t/modules/Require/AutomatedTesting.t
+++ b/t/modules/Require/AutomatedTesting.t
@@ -1,8 +1,7 @@
 use Test2::Bundle::Extended -target => 'Test2::Require::AutomatedTesting';
 
 {
-    local %ENV = %ENV;
-    $ENV{AUTOMATED_TESTING} = 0;
+    local $ENV{AUTOMATED_TESTING} = 0;
     is($CLASS->skip(), 'Automated test, set the $AUTOMATED_TESTING environment variable to run it', "will skip");
 
     $ENV{AUTOMATED_TESTING} = 1;

--- a/t/modules/Require/ExtendedTesting.t
+++ b/t/modules/Require/ExtendedTesting.t
@@ -1,8 +1,7 @@
 use Test2::Bundle::Extended -target => 'Test2::Require::ExtendedTesting';
 
 {
-    local %ENV = %ENV;
-    $ENV{EXTENDED_TESTING} = 0;
+    local $ENV{EXTENDED_TESTING} = 0;
     is($CLASS->skip(), 'Extended test, set the $EXTENDED_TESTING environment variable to run it', "will skip");
 
     $ENV{EXTENDED_TESTING} = 1;

--- a/t/modules/Require/NonInteractiveTesting.t
+++ b/t/modules/Require/NonInteractiveTesting.t
@@ -1,8 +1,7 @@
 use Test2::Bundle::Extended -target => 'Test2::Require::NonInteractiveTesting';
 
 {
-    local %ENV = %ENV;
-    $ENV{NONINTERACTIVE_TESTING} = 0;
+    local $ENV{NONINTERACTIVE_TESTING} = 0;
     is($CLASS->skip(), 'NonInteractive test, set the $NONINTERACTIVE_TESTING environment variable to run it', "will skip");
 
     $ENV{NONINTERACTIVE_TESTING} = 1;

--- a/t/modules/Require/ReleaseTesting.t
+++ b/t/modules/Require/ReleaseTesting.t
@@ -1,8 +1,7 @@
 use Test2::Bundle::Extended -target => 'Test2::Require::ReleaseTesting';
 
 {
-    local %ENV = %ENV;
-    $ENV{RELEASE_TESTING} = 0;
+    local $ENV{RELEASE_TESTING} = 0;
     is($CLASS->skip(), 'Release test, set the $RELEASE_TESTING environment variable to run it', "will skip");
 
     $ENV{RELEASE_TESTING} = 1;

--- a/t/regression/291-async-subtest-done-testing.t
+++ b/t/regression/291-async-subtest-done-testing.t
@@ -1,4 +1,11 @@
 use Test2::V0;
+
+BEGIN {
+    require Config;
+    skip_all('no fork')
+        unless ($Config::Config{d_fork} or $Config::Config{d_pseudofork});
+}
+
 use Test2::Tools::AsyncSubtest qw/fork_subtest/;
 
 my $st = fork_subtest foo => sub {


### PR DESCRIPTION
Several Test2 tests are failing in Perl core on VMS.  This gets them passing.